### PR TITLE
Remember collection parameters

### DIFF
--- a/mxcubecore/HardwareObjects/ANSTO/Detector.py
+++ b/mxcubecore/HardwareObjects/ANSTO/Detector.py
@@ -129,4 +129,4 @@ class Detector(AbstractDetector):
         return self._get_detector_config("x_pixels_in_detector")
 
     def get_height(self):
-        return self._get_detector_config("x_pixels_in_detector")
+        return self._get_detector_config("y_pixels_in_detector")

--- a/mxcubecore/HardwareObjects/ANSTO/Detector.py
+++ b/mxcubecore/HardwareObjects/ANSTO/Detector.py
@@ -124,3 +124,9 @@ class Detector(AbstractDetector):
         """
 
         return self._beam_centre
+
+    def get_width(self):
+        return self._get_detector_config("x_pixels_in_detector")
+
+    def get_height(self):
+        return self._get_detector_config("x_pixels_in_detector")

--- a/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
@@ -8,6 +8,9 @@ from time import perf_counter
 import gevent
 import redis
 from gevent.event import Event
+import yaml
+from os import path
+
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObject
@@ -110,13 +113,15 @@ class PrefectWorkflow(HardwareObject):
         self.gevent_event = None
         self.workflow_name = None
 
-        self.REDIS_HOST = os.environ.get("MXCUBE_REDIS_HOST", "mx_redis")
+        self.REDIS_HOST = os.environ.get("MXCUBE_REDIS_HOST", "localhost")
         self.REDIS_PORT = int(os.environ.get("MXCUBE_REDIS_PORT", "6379"))
         self.REDIS_USERNAME = os.environ.get("MXCUBE_REDIS_USERNAME", None)
         self.REDIS_PASSWORD = os.environ.get("MXCUBE_REDIS_PASSWORD", None)
         self.REDIS_DB = int(os.environ.get("MXCUBE_REDIS_DB", "0"))
 
         self.mxcubecore_workflow_aborted = False
+
+
 
     def _init(self) -> None:
         """
@@ -148,6 +153,9 @@ class PrefectWorkflow(HardwareObject):
             password=self.REDIS_PASSWORD,
             db=self.REDIS_DB,
         )
+
+        self._save_default_collection_params_to_redis()
+
 
         self.raster_flow = None
 
@@ -460,3 +468,30 @@ class PrefectWorkflow(HardwareObject):
                 f"Workflow {self.workflow_name} not supported"
             )
             self.state.value = "ON"
+
+    def _save_default_collection_params_to_redis(self) -> None:
+        """
+        Save default full_dataset, screening, and grid_scan parameters to Redis.
+        The default values are read from the default_params.yml config file
+        
+        Returns
+        -------
+        None
+        """
+        default_params_path =  path.join(path.dirname(__file__), "prefect_flows", "default_params.yml")
+        with open(default_params_path) as config:
+            default_params = yaml.safe_load(config)
+
+        collection_type = "full_dataset"
+        for key, value in default_params[collection_type].items():
+            self.redis_connection.set(f"{collection_type}:{key}", value)
+
+
+        collection_type = "screening"
+        for key, value in default_params[collection_type].items():
+            self.redis_connection.set(f"{collection_type}:{key}", value)
+
+
+        collection_type = "grid_scan"
+        for key, value in default_params[collection_type].items():
+            self.redis_connection.set(f"{collection_type}:{key}", value)

--- a/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
@@ -3,14 +3,13 @@ import logging
 import os
 import pprint
 import time
+from os import path
 from time import perf_counter
 
 import gevent
 import redis
-from gevent.event import Event
 import yaml
-from os import path
-
+from gevent.event import Event
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObject
@@ -121,8 +120,6 @@ class PrefectWorkflow(HardwareObject):
 
         self.mxcubecore_workflow_aborted = False
 
-
-
     def _init(self) -> None:
         """
         Object initialisation - executed *before* loading contents
@@ -155,7 +152,6 @@ class PrefectWorkflow(HardwareObject):
         )
 
         self._save_default_collection_params_to_redis()
-
 
         self.raster_flow = None
 
@@ -473,12 +469,14 @@ class PrefectWorkflow(HardwareObject):
         """
         Save default full_dataset, screening, and grid_scan parameters to Redis.
         The default values are read from the default_params.yml config file
-        
+
         Returns
         -------
         None
         """
-        default_params_path =  path.join(path.dirname(__file__), "prefect_flows", "default_params.yml")
+        default_params_path = path.join(
+            path.dirname(__file__), "prefect_flows", "default_params.yml"
+        )
         with open(default_params_path) as config:
             default_params = yaml.safe_load(config)
 
@@ -486,11 +484,9 @@ class PrefectWorkflow(HardwareObject):
         for key, value in default_params[collection_type].items():
             self.redis_connection.set(f"{collection_type}:{key}", value)
 
-
         collection_type = "screening"
         for key, value in default_params[collection_type].items():
             self.redis_connection.set(f"{collection_type}:{key}", value)
-
 
         collection_type = "grid_scan"
         for key, value in default_params[collection_type].items():

--- a/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
@@ -417,8 +417,8 @@ class PrefectWorkflow(HardwareObject):
         if self.workflow_name == PrefectFlows.screen_sample:
             logging.getLogger("HWR").info(f"Starting workflow: {self.workflow_name}")
             self.screening_flow = ScreeningFlow(
-                state=self._state,  resolution=self.resolution
-                )
+                state=self._state, resolution=self.resolution
+            )
             dialog_box_parameters = self.open_dialog(self.screening_flow.dialog_box())
             if dialog_box_parameters:
                 logging.getLogger("HWR").info(
@@ -433,8 +433,8 @@ class PrefectWorkflow(HardwareObject):
         elif self.workflow_name == PrefectFlows.collect_dataset:
             logging.getLogger("HWR").info(f"Starting workflow: {self.workflow_name}")
             self.full_dataset_flow = FullDatasetFlow(
-                state=self._state,  resolution=self.resolution
-                )
+                state=self._state, resolution=self.resolution
+            )
             dialog_box_parameters = self.open_dialog(
                 self.full_dataset_flow.dialog_box()
             )

--- a/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
@@ -20,6 +20,7 @@ from .prefect_flows.full_dataset_collection_flow import FullDatasetFlow
 from .prefect_flows.grid_scan_flow import GridScanFlow
 from .prefect_flows.schemas.prefect_workflow import PrefectFlows
 from .prefect_flows.screening_flow import ScreeningFlow
+from .Resolution import Resolution
 
 
 class State(object):
@@ -142,6 +143,7 @@ class PrefectWorkflow(HardwareObject):
 
         hwr = HWR.get_hardware_repository()
         self.sample_view: SampleView = hwr.get_hardware_object("/sample_view")
+        self.resolution: Resolution = hwr.get_hardware_object("/resolution")
 
         self.redis_connection = redis.StrictRedis(
             host=self.REDIS_HOST,
@@ -414,7 +416,9 @@ class PrefectWorkflow(HardwareObject):
 
         if self.workflow_name == PrefectFlows.screen_sample:
             logging.getLogger("HWR").info(f"Starting workflow: {self.workflow_name}")
-            self.screening_flow = ScreeningFlow(state=self._state)
+            self.screening_flow = ScreeningFlow(
+                state=self._state,  resolution=self.resolution
+                )
             dialog_box_parameters = self.open_dialog(self.screening_flow.dialog_box())
             if dialog_box_parameters:
                 logging.getLogger("HWR").info(
@@ -428,7 +432,9 @@ class PrefectWorkflow(HardwareObject):
 
         elif self.workflow_name == PrefectFlows.collect_dataset:
             logging.getLogger("HWR").info(f"Starting workflow: {self.workflow_name}")
-            self.full_dataset_flow = FullDatasetFlow(state=self._state)
+            self.full_dataset_flow = FullDatasetFlow(
+                state=self._state,  resolution=self.resolution
+                )
             dialog_box_parameters = self.open_dialog(
                 self.full_dataset_flow.dialog_box()
             )
@@ -447,6 +453,7 @@ class PrefectWorkflow(HardwareObject):
                 sample_view=self.sample_view,
                 state=self._state,
                 redis_connection=self.redis_connection,
+                resolution=self.resolution,
             )
             dialog_box_parameters = self.open_dialog(self.raster_flow.dialog_box())
             if dialog_box_parameters:

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/abstract_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/abstract_flow.py
@@ -37,7 +37,7 @@ DATA_LAYER_API = getenv("DATA_LAYER_API", "http://0.0.0.0:8088")
 EPN_STRING = getenv(
     "EPN_STRING", "my_epn"
 )  # TODO: could be obtained from somewhere else
-SIMPLON_API = getenv("SIMPLON_API", "http://0.0.0.0:8088")
+SIMPLON_API = getenv("SIMPLON_API", "http://0.0.0.0:8000")
 
 
 class AbstractPrefectWorkflow(ABC):

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/abstract_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/abstract_flow.py
@@ -11,20 +11,20 @@ from time import (
     perf_counter,
     sleep,
 )
+from typing import Literal
 from urllib.parse import urljoin
 
 import gevent
 import httpx
-from mx_robot_library.client import Client
 import redis
-from typing import Literal
+from mx_robot_library.client import Client
 
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 
 from .schemas.data_layer import PinRead
 from .schemas.full_dataset import FullDatasetDialogBox
-from .schemas.screening import ScreeningDialogBox
 from .schemas.grid_scan import GridScanDialogBox
+from .schemas.screening import ScreeningDialogBox
 
 ROBOT_HOST = getenv("ROBOT_HOST", "127.0.0.0")
 DATA_LAYER_API = getenv("DATA_LAYER_API", "http://0.0.0.0:8088")
@@ -82,8 +82,7 @@ class AbstractPrefectWorkflow(ABC):
         self.REDIS_PASSWORD = os.environ.get("MXCUBE_REDIS_PASSWORD", None)
         self.REDIS_DB = int(os.environ.get("MXCUBE_REDIS_DB", "0"))
 
-        self._collection_type = None # To be overridden by inheriting classes
-
+        self._collection_type = None  # To be overridden by inheriting classes
 
     @abstractmethod
     def run(self) -> None:
@@ -288,7 +287,7 @@ class AbstractPrefectWorkflow(ABC):
 
     def _get_redis_connection(self) -> redis.StrictRedis:
         """Create and return a Redis connection.
-        
+
         Returns
         -------
         redis.StrictRedis
@@ -308,7 +307,7 @@ class AbstractPrefectWorkflow(ABC):
     ) -> None:
         """
         Save the last set parameters from the dialog box to Redis.
-        
+
         Parameters
         ----------
         dialog_box : ScreeningDialogBox | FullDatasetDialogBox | GridScanDialogBox
@@ -328,7 +327,7 @@ class AbstractPrefectWorkflow(ABC):
             "crystal_counter",
             "photon_energy",
             "detector_distance",
-            "md3_alignment_y_speed"
+            "md3_alignment_y_speed",
         ],
     ) -> str | int | float:
         """
@@ -347,7 +346,7 @@ class AbstractPrefectWorkflow(ABC):
             "md3_alignment_y_speed"
         ]
             A parameter saved in redis
-        
+
         Returns
         -------
         str | int | float

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/abstract_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/abstract_flow.py
@@ -335,6 +335,7 @@ class AbstractPrefectWorkflow(ABC):
             "photon_energy",
             "resolution",
             "md3_alignment_y_speed",
+            "transmission"
         ],
     ) -> str | int | float:
         """
@@ -349,8 +350,9 @@ class AbstractPrefectWorkflow(ABC):
             "processing_pipeline",
             "crystal_counter",
             "photon_energy",
-            "detector_distance",
+            "resolution",
             "md3_alignment_y_speed"
+            "transmission"
         ]
             A parameter saved in redis
 

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
@@ -23,6 +23,6 @@ screening:
 grid_scan:
   md3_alignment_y_speed: 1  # mm/s
   omega_range: 0.0  # Degrees
-  detector_distance: 340.0  # mm
+  photon_energy: 13.0  # keV
   resolution: 4.0  # Ångström
   transmission: 2  # Percentage

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
@@ -1,0 +1,23 @@
+full_dataset:
+  exposure_time: 18.0 # Total exposure time, seconds
+  omega_range: 180.0 # Degrees
+  number_of_frames: 180
+  processing_pipeline: "fast_dp" # can be fast_dp, dials, or dials_and_fast_dp
+  crystal_counter: 0 # a.k.a. crystal id
+  photon_energy: 13.0 # keV
+  detector_distance: 340.0 # mm
+
+screening:
+  exposure_time: 18.0 # Total exposure time, seconds
+  omega_range: 180.0 # Degrees
+  number_of_frames: 1800
+  processing_pipeline: "fast_dp" # can be fast_dp, dials, or dials_and_fast_dp
+  crystal_counter: 0 # a.k.a. crystal id
+  photon_energy: 13.0 # keV
+  detector_distance: 340.0 # mm
+
+grid_scan:
+  md3_alignment_y_speed: 1 # mm/s
+  omega_range: 0.0 # Degrees
+  detector_distance: 340.0 # mm
+  photon_energy: 13.0 # keV

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
@@ -1,29 +1,28 @@
 ---
 full_dataset:
-  exposure_time: 28.0  # Total exposure time, seconds
-  omega_range: 280.0  # Degrees
-  number_of_frames: 2800
+  exposure_time: 9.0  # Total exposure time, seconds
+  omega_range: 180.0  # Degrees
+  number_of_frames: 3600
   processing_pipeline: "fast_dp"  # can be fast_dp, dials, or dials_and_fast_dp
   crystal_counter: 0  # a.k.a. crystal id
   photon_energy: 13.0  # keV
-  resolution: 1.157 # Ångström
-  transmission: 2 # Percentage
+  resolution: 2.0  # Ångström
+  transmission: 2  # Percentage
 
 screening:
   exposure_time: 2.0  # Total exposure time, seconds
   omega_range: 20.0  # Degrees
-  number_of_frames: 200
+  number_of_frames: 400
   processing_pipeline: "fast_dp"  # can be fast_dp, dials, or dials_and_fast_dp
   crystal_counter: 0  # a.k.a. crystal id
   photon_energy: 13.0  # keV
-  resolution: 1.157 # Ångström
-  transmission: 2 # Percentage
+  resolution: 2  # Ångström
+  transmission: 1  # Percentage
 
 
 grid_scan:
   md3_alignment_y_speed: 1  # mm/s
   omega_range: 0.0  # Degrees
   detector_distance: 340.0  # mm
-  resolution: 1.157 # Ångström
-  transmission: 2 # Percentage
-
+  resolution: 4.0  # Ångström
+  transmission: 2  # Percentage

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
@@ -1,23 +1,24 @@
+---
 full_dataset:
-  exposure_time: 18.0 # Total exposure time, seconds
-  omega_range: 180.0 # Degrees
-  number_of_frames: 180
-  processing_pipeline: "fast_dp" # can be fast_dp, dials, or dials_and_fast_dp
-  crystal_counter: 0 # a.k.a. crystal id
-  photon_energy: 13.0 # keV
-  detector_distance: 340.0 # mm
+  exposure_time: 28.0  # Total exposure time, seconds
+  omega_range: 280.0  # Degrees
+  number_of_frames: 2800
+  processing_pipeline: "fast_dp"  # can be fast_dp, dials, or dials_and_fast_dp
+  crystal_counter: 0  # a.k.a. crystal id
+  photon_energy: 13.0  # keV
+  detector_distance: 300.0  # mm
 
 screening:
-  exposure_time: 18.0 # Total exposure time, seconds
-  omega_range: 180.0 # Degrees
-  number_of_frames: 1800
-  processing_pipeline: "fast_dp" # can be fast_dp, dials, or dials_and_fast_dp
-  crystal_counter: 0 # a.k.a. crystal id
-  photon_energy: 13.0 # keV
-  detector_distance: 340.0 # mm
+  exposure_time: 2.0  # Total exposure time, seconds
+  omega_range: 20.0  # Degrees
+  number_of_frames: 200
+  processing_pipeline: "fast_dp"  # can be fast_dp, dials, or dials_and_fast_dp
+  crystal_counter: 0  # a.k.a. crystal id
+  photon_energy: 13.0  # keV
+  detector_distance: 340.0  # mm
 
 grid_scan:
-  md3_alignment_y_speed: 1 # mm/s
-  omega_range: 0.0 # Degrees
-  detector_distance: 340.0 # mm
-  photon_energy: 13.0 # keV
+  md3_alignment_y_speed: 1  # mm/s
+  omega_range: 0.0  # Degrees
+  detector_distance: 340.0  # mm
+  photon_energy: 13.0  # keV

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
@@ -6,7 +6,8 @@ full_dataset:
   processing_pipeline: "fast_dp"  # can be fast_dp, dials, or dials_and_fast_dp
   crystal_counter: 0  # a.k.a. crystal id
   photon_energy: 13.0  # keV
-  detector_distance: 300.0  # mm
+  resolution: 1.157 # Ångström
+  transmission: 2 # Percentage
 
 screening:
   exposure_time: 2.0  # Total exposure time, seconds
@@ -15,10 +16,14 @@ screening:
   processing_pipeline: "fast_dp"  # can be fast_dp, dials, or dials_and_fast_dp
   crystal_counter: 0  # a.k.a. crystal id
   photon_energy: 13.0  # keV
-  detector_distance: 340.0  # mm
+  resolution: 1.157 # Ångström
+  transmission: 2 # Percentage
+
 
 grid_scan:
   md3_alignment_y_speed: 1  # mm/s
   omega_range: 0.0  # Degrees
   detector_distance: 340.0  # mm
-  photon_energy: 13.0  # keV
+  resolution: 1.157 # Ångström
+  transmission: 2 # Percentage
+

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
@@ -147,7 +147,7 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
                 "widget": "textarea",
             },
             "resolution": {
-                "title": "Resolution [A]",
+                "title": "Resolution [Å]",
                 "type": "number",
                 "minimum": 0,  # TODO: get limits from distance PV
                 "maximum": 3000,  # TODO: get limits from distance PV

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
@@ -47,6 +47,7 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
         dialog_box_model = FullDatasetDialogBox.parse_obj(dialog_box_parameters)
 
         detector_distance = self._resolution_to_distance(dialog_box_model.resolution, energy=dialog_box_model.photon_energy)
+
         full_dataset_params = FullDatasetParams(
             omega_range=dialog_box_model.omega_range,
             exposure_time=dialog_box_model.exposure_time,
@@ -56,7 +57,8 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
             detector_distance=detector_distance,
             photon_energy=dialog_box_model.photon_energy,
             beam_size=(80, 80),  # TODO: get beam size,
-            transmission=transmission.get(),
+            # Convert transmission percentage to a value between 0 and 1
+            transmission=dialog_box_model.transmission / 100,
         )
 
         if not ADD_DUMMY_PIN_TO_DB:
@@ -156,6 +158,14 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
                 "default": float(self._get_dialog_box_param("photon_energy")),
                 "widget": "textarea",
             },
+            "transmission": {
+                "title": "Transmission [%]",
+                "type": "number",
+                "minimum": 0,  # TODO: get limits from PV?
+                "maximum": 100,
+                "default": float(self._get_dialog_box_param("transmission")),
+                "widget": "textarea",
+            },
             "processing_pipeline": {
                 "title": "Data Processing Pipeline",
                 "type": "string",
@@ -189,6 +199,7 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
                 "photon_energy",
                 "processing_pipeline",
                 "crystal_counter",
+                "transmission"
             ],
             "dialogName": "Dataset Parameters",
         }

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
@@ -11,13 +11,13 @@ from mx3_beamline_library.devices.motors import actual_sample_detector_distance
 
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 
+from ..Resolution import Resolution
 from .abstract_flow import AbstractPrefectWorkflow
 from .prefect_client import MX3PrefectClient
 from .schemas.full_dataset import (
     FullDatasetDialogBox,
     FullDatasetParams,
 )
-from ..Resolution import Resolution
 
 FULL_DATASET_DEPLOYMENT_NAME = environ.get(
     "FULL_DATASET_DEPLOYMENT_NAME", "mxcube-full-data-collection/plans"
@@ -46,7 +46,11 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
         # This is the payload we get from the UI
         dialog_box_model = FullDatasetDialogBox.parse_obj(dialog_box_parameters)
 
-        detector_distance = self._resolution_to_distance(dialog_box_model.resolution, energy=dialog_box_model.photon_energy)
+        detector_distance = self._resolution_to_distance(
+            dialog_box_model.resolution,
+            energy=dialog_box_model.photon_energy,
+            roi_mode="disabled",
+        )
 
         full_dataset_params = FullDatasetParams(
             omega_range=dialog_box_model.omega_range,
@@ -199,7 +203,7 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
                 "photon_energy",
                 "processing_pipeline",
                 "crystal_counter",
-                "transmission"
+                "transmission",
             ],
             "dialogName": "Dataset Parameters",
         }

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 from os import environ
-from typing import Literal
 
 import redis
 from mx3_beamline_library.devices.beam import (
@@ -134,7 +133,7 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
             },
             "number_of_frames": {
                 "title": "Number of Frames",
-                "type": "number",
+                "type": "integer",
                 "minimum": 1,
                 "default": int(self._get_dialog_box_param("number_of_frames")),
                 "widget": "textarea",
@@ -163,7 +162,7 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
             },
             "crystal_counter": {
                 "title": "Crystal ID",
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "default": int(self._get_dialog_box_param("crystal_counter")),
                 "widget": "textarea",

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
@@ -133,7 +133,7 @@ class GridScanFlow(AbstractPrefectWorkflow):
         logging.getLogger("HWR").info(
             f"Parameters sent to prefect flow: {prefect_parameters}"
         )
-    
+
         # Remember the collection params for the next collection
         self._save_dialog_box_params_to_redis(dialog_box_model)
 
@@ -337,7 +337,9 @@ class GridScanFlow(AbstractPrefectWorkflow):
                     "type": "number",
                     "minimum": 0,
                     "maximum": 14.8,
-                    "default": float(self._get_dialog_box_param("md3_alignment_y_speed")),
+                    "default": float(
+                        self._get_dialog_box_param("md3_alignment_y_speed")
+                    ),
                     "widget": "textarea",
                 },
                 "omega_range": {

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
@@ -360,7 +360,7 @@ class GridScanFlow(AbstractPrefectWorkflow):
                     "widget": "textarea",
                 },
                 "resolution": {
-                    "title": "Resolution [A]",
+                    "title": "Resolution [Å]",
                     "type": "number",
                     "minimum": 0,  # TODO: get limits from distance PV
                     "maximum": 3000,  # TODO: get limits from distance PV

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
@@ -27,6 +27,7 @@ from .schemas.grid_scan import (
     GridScanDialogBox,
     GridScanParams,
 )
+from ..Resolution import Resolution
 
 GRID_SCAN_DEPLOYMENT_NAME = environ.get(
     "GRID_SCAN_DEPLOYMENT_NAME", "mxcube-grid-scan/plans"
@@ -46,10 +47,11 @@ class GridScanFlow(AbstractPrefectWorkflow):
     def __init__(
         self,
         state,
+        resolution: Resolution,
         redis_connection: redis.StrictRedis,
         sample_view: SampleView,
     ) -> None:
-        super().__init__(state)
+        super().__init__(state, resolution)
 
         self.redis_connection = redis_connection
         self.sample_view = sample_view
@@ -109,6 +111,8 @@ class GridScanFlow(AbstractPrefectWorkflow):
         else:
             grid_scan_id = int(redis_grid_scan_id) + 1
 
+        detector_distance = self._resolution_to_distance(dialog_box_model.resolution, energy=dialog_box_model.photon_energy)
+
         prefect_parameters = GridScanParams(
             sample_id=sample_id,
             grid_scan_id=grid_scan_id,
@@ -118,13 +122,14 @@ class GridScanFlow(AbstractPrefectWorkflow):
             beam_position=beam_position,
             number_of_columns=num_cols,
             number_of_rows=num_rows,
-            detector_distance=dialog_box_model.detector_distance / 1000,
+            detector_distance=detector_distance,
             photon_energy=dialog_box_model.photon_energy,
             omega_range=dialog_box_model.omega_range,
             md3_alignment_y_speed=dialog_box_model.md3_alignment_y_speed,
             hardware_trigger=True,
             number_of_processes=GRID_SCAN_NUMBER_OF_PROCESSES,
-            transmission=transmission.get(),
+            # Convert transmission percentage to a value between 0 and 1
+            transmission=dialog_box_model.transmission / 100
         )
 
         self.redis_connection.set(
@@ -350,12 +355,12 @@ class GridScanFlow(AbstractPrefectWorkflow):
                     "default": float(self._get_dialog_box_param("omega_range")),
                     "widget": "textarea",
                 },
-                "detector_distance": {
-                    "title": "Detector Distance [mm]",
+                "resolution": {
+                    "title": "Resolution [A]",
                     "type": "number",
                     "minimum": 0,  # TODO: get limits from distance PV
                     "maximum": 3000,  # TODO: get limits from distance PV
-                    "default": float(self._get_dialog_box_param("detector_distance")),
+                    "default": float(self._get_dialog_box_param("resolution")),
                     "widget": "textarea",
                 },
                 "photon_energy": {
@@ -366,12 +371,21 @@ class GridScanFlow(AbstractPrefectWorkflow):
                     "default": float(self._get_dialog_box_param("photon_energy")),
                     "widget": "textarea",
                 },
+                "transmission": {
+                    "title": "Transmission [%]",
+                    "type": "number",
+                    "minimum": 0,  # TODO: get limits from PV?
+                    "maximum": 100,
+                    "default": float(self._get_dialog_box_param("transmission")),
+                    "widget": "textarea",
+                },
             },
             "required": [
                 "md3_alignment_y_speed",
                 "omega_range",
-                "detector_distance",
+                "resolution",
                 "photon_energy",
+                "transmission"
             ],
             "dialogName": "Grid Scan Parameters",
         }

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
@@ -21,13 +21,13 @@ from mxcubecore.HardwareObjects.SampleView import (
 )
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 
+from ..Resolution import Resolution
 from .abstract_flow import AbstractPrefectWorkflow
 from .prefect_client import MX3PrefectClient
 from .schemas.grid_scan import (
     GridScanDialogBox,
     GridScanParams,
 )
-from ..Resolution import Resolution
 
 GRID_SCAN_DEPLOYMENT_NAME = environ.get(
     "GRID_SCAN_DEPLOYMENT_NAME", "mxcube-grid-scan/plans"
@@ -111,7 +111,11 @@ class GridScanFlow(AbstractPrefectWorkflow):
         else:
             grid_scan_id = int(redis_grid_scan_id) + 1
 
-        detector_distance = self._resolution_to_distance(dialog_box_model.resolution, energy=dialog_box_model.photon_energy)
+        detector_distance = self._resolution_to_distance(
+            dialog_box_model.resolution,
+            energy=dialog_box_model.photon_energy,
+            roi_mode="4M",
+        )
 
         prefect_parameters = GridScanParams(
             sample_id=sample_id,
@@ -129,7 +133,7 @@ class GridScanFlow(AbstractPrefectWorkflow):
             hardware_trigger=True,
             number_of_processes=GRID_SCAN_NUMBER_OF_PROCESSES,
             # Convert transmission percentage to a value between 0 and 1
-            transmission=dialog_box_model.transmission / 100
+            transmission=dialog_box_model.transmission / 100,
         )
 
         self.redis_connection.set(
@@ -385,7 +389,7 @@ class GridScanFlow(AbstractPrefectWorkflow):
                 "omega_range",
                 "resolution",
                 "photon_energy",
-                "transmission"
+                "transmission",
             ],
             "dialogName": "Grid Scan Parameters",
         }

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/full_dataset.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/full_dataset.py
@@ -19,14 +19,13 @@ class FullDatasetDialogBox(BaseModel):
     resolution: float = Field(
         description="Measured in Angstrom. This value is converted to "
         "distance in meters internally, which is the parameter "
-        "prefect expects")
+        "prefect expects"
+    )
     photon_energy: float
     sample_id: Optional[str] = None
     processing_pipeline: str
     crystal_counter: int
-    transmission: float = Field(
-        "Measured in percentage"
-    )
+    transmission: float = Field(description="Measured in percentage")
 
 
 class FullDatasetParams(BaseModel):

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/full_dataset.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/full_dataset.py
@@ -16,7 +16,10 @@ class FullDatasetDialogBox(BaseModel):
     exposure_time: float
     omega_range: float
     number_of_frames: int
-    detector_distance: float = Field(description="Measured in millimeters")
+    resolution: float = Field(
+        description="Measured in Angstrom. This value is converted to "
+        "distance in meters internally, which is the parameter "
+        "prefect expects")
     photon_energy: float
     sample_id: Optional[str] = None
     processing_pipeline: str = "dials"

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/full_dataset.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/full_dataset.py
@@ -22,8 +22,11 @@ class FullDatasetDialogBox(BaseModel):
         "prefect expects")
     photon_energy: float
     sample_id: Optional[str] = None
-    processing_pipeline: str = "dials"
-    crystal_counter: int = 0
+    processing_pipeline: str
+    crystal_counter: int
+    transmission: float = Field(
+        "Measured in percentage"
+    )
 
 
 class FullDatasetParams(BaseModel):
@@ -46,7 +49,7 @@ class FullDatasetParams(BaseModel):
     )
     detector_distance: float = Field(description="Output from XPLAN. Measured in m.")
     photon_energy: float = Field(description="Global default. Measured in keV.")
-    transmission: float
+    transmission: float = Field(strict=True, ge=0, le=1)
     beam_size: Union[tuple[int, int], list[int]] = Field(
         default=(80, 80),
         description="Determined by the crystal finder. Not currently used. "

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/full_dataset.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/full_dataset.py
@@ -18,7 +18,6 @@ class FullDatasetDialogBox(BaseModel):
     number_of_frames: int
     detector_distance: float = Field(description="Measured in millimeters")
     photon_energy: float
-    hardware_trigger: bool = True
     sample_id: Optional[str] = None
     processing_pipeline: str = "dials"
     crystal_counter: int = 0

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/grid_scan.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/grid_scan.py
@@ -12,8 +12,13 @@ from pydantic import (
 class GridScanDialogBox(BaseModel):
     md3_alignment_y_speed: float
     omega_range: float
-    detector_distance: float = Field(description="Distance measured in millimeters")
+    resolution: float = Field(
+        description="Measured in Angstrom. This value is converted to "
+        "distance in meters internally, which is the parameter "
+        "prefect expects")    
     photon_energy: float
+    transmission: float = Field(description="Measured in percentage")
+
 
 
 class GridScanParams(BaseModel):
@@ -33,4 +38,4 @@ class GridScanParams(BaseModel):
     hardware_trigger: bool = True
     crystal_finder_threshold: int = 1
     number_of_processes: Optional[float] = None
-    transmission: float
+    transmission: float = Field(strict=True, ge=0, le=1)

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/grid_scan.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/grid_scan.py
@@ -14,7 +14,6 @@ class GridScanDialogBox(BaseModel):
     omega_range: float
     detector_distance: float = Field(description="Distance measured in millimeters")
     photon_energy: float
-    hardware_trigger: bool = True
 
 
 class GridScanParams(BaseModel):

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/grid_scan.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/grid_scan.py
@@ -15,10 +15,10 @@ class GridScanDialogBox(BaseModel):
     resolution: float = Field(
         description="Measured in Angstrom. This value is converted to "
         "distance in meters internally, which is the parameter "
-        "prefect expects")    
+        "prefect expects"
+    )
     photon_energy: float
     transmission: float = Field(description="Measured in percentage")
-
 
 
 class GridScanParams(BaseModel):

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/screening.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/screening.py
@@ -19,7 +19,6 @@ class ScreeningDialogBox(BaseModel):
     detector_distance: float = Field(description="Detector distance in millimeters")
     photon_energy: float = Field(description="Detector distance in keV")
     transmission: float = 0.1
-    hardware_trigger: bool = True
     sample_id: Optional[str] = None
     processing_pipeline: str = "dials"
     crystal_counter: int = 0

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/screening.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/screening.py
@@ -16,9 +16,12 @@ class ScreeningDialogBox(BaseModel):
     exposure_time: float
     omega_range: float
     number_of_frames: int
-    detector_distance: float = Field(description="Detector distance in millimeters")
+    resolution: float = Field(
+        description="Measured in Angstrom. This value is converted to "
+        "distance in meters internally, which is the parameter "
+        "prefect expects")
     photon_energy: float = Field(description="Detector distance in keV")
-    transmission: float = 0.1
+    transmission: float = Field(description="Measured in percentage")
     sample_id: Optional[str] = None
     processing_pipeline: str = "dials"
     crystal_counter: int = 0
@@ -42,7 +45,7 @@ class ScreeningParams(BaseModel):
     number_of_frames: int
     detector_distance: float = Field(description="Detector distance in meters")
     photon_energy: float = Field(description="Measured in keV.")
-    transmission: float
+    transmission: float = Field(strict=True, ge=0, le=1)
     beam_size: Union[tuple[int, int], list[int]] = Field(
         default=(80, 80),
         description="Determined by the crystal finder. Not currently used. "

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/screening.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/screening.py
@@ -19,7 +19,8 @@ class ScreeningDialogBox(BaseModel):
     resolution: float = Field(
         description="Measured in Angstrom. This value is converted to "
         "distance in meters internally, which is the parameter "
-        "prefect expects")
+        "prefect expects"
+    )
     photon_energy: float = Field(description="Detector distance in keV")
     transmission: float = Field(description="Measured in percentage")
     sample_id: Optional[str] = None

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
@@ -9,7 +9,6 @@ from mx3_beamline_library.devices.beam import (
 from mx3_beamline_library.devices.motors import actual_sample_detector_distance
 
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
-from typing import Literal
 
 from .abstract_flow import AbstractPrefectWorkflow
 from .prefect_client import MX3PrefectClient
@@ -132,7 +131,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
             },
             "number_of_frames": {
                 "title": "Number of Frames",
-                "type": "number",
+                "type": "integer",
                 "minimum": 1,
                 "default": int(self._get_dialog_box_param("number_of_frames")),
                 "widget": "textarea",
@@ -161,7 +160,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
             },
             "crystal_counter": {
                 "title": "Crystal ID",
-                "type": "number",
+                "type": "integer",
                 "minimum": 0,
                 "default": int(self._get_dialog_box_param("crystal_counter")),
                 "widget": "textarea",

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
@@ -145,7 +145,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
                 "widget": "textarea",
             },
             "resolution": {
-                "title": "Resolution [A]",
+                "title": "Resolution [Å]",
                 "type": "number",
                 "minimum": 0,  # TODO: get limits from distance PV
                 "maximum": 3000,  # TODO: get limits from distance PV

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
@@ -9,6 +9,7 @@ from mx3_beamline_library.devices.beam import (
 from mx3_beamline_library.devices.motors import actual_sample_detector_distance
 
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
+from typing import Literal
 
 from .abstract_flow import AbstractPrefectWorkflow
 from .prefect_client import MX3PrefectClient
@@ -24,6 +25,12 @@ ADD_DUMMY_PIN_TO_DB = environ.get("ADD_DUMMY_PIN_TO_DB", "false").lower() == "tr
 
 
 class ScreeningFlow(AbstractPrefectWorkflow):
+
+    def __init__(self, state):
+        super().__init__(state)
+
+        self._collection_type = "screening"
+
     def run(self, dialog_box_parameters: dict) -> None:
         """Runs the screening flow
 
@@ -67,7 +74,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
             "crystal_counter": dialog_box_model.crystal_counter,
             "screening_params": screening_params.dict(),
             "run_data_processing_pipeline": True,
-            "hardware_trigger": dialog_box_model.hardware_trigger,
+            "hardware_trigger": True,
             "add_dummy_pin": ADD_DUMMY_PIN_TO_DB,
             "pipeline": dialog_box_model.processing_pipeline,
             "data_processing_config": None,
@@ -80,6 +87,10 @@ class ScreeningFlow(AbstractPrefectWorkflow):
         screening_flow = MX3PrefectClient(
             name=SCREENING_DEPLOYMENT_NAME, parameters=prefect_parameters
         )
+
+        # Remember the collection params for the next collection
+        self._save_dialog_box_params_to_redis(dialog_box_model)
+
         try:
             loop = self._get_asyncio_event_loop()
             asyncio.set_event_loop(loop)
@@ -108,7 +119,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
                 "title": "Total Exposure Time [s]",
                 "type": "number",
                 "minimum": 0,
-                "default": 1,
+                "default": float(self._get_dialog_box_param("exposure_time")),
                 "widget": "textarea",
             },
             "omega_range": {
@@ -116,14 +127,14 @@ class ScreeningFlow(AbstractPrefectWorkflow):
                 "type": "number",
                 "minimum": 0,
                 "exclusiveMaximum": 361,
-                "default": 10,
+                "default": float(self._get_dialog_box_param("omega_range")),
                 "widget": "textarea",
             },
             "number_of_frames": {
                 "title": "Number of Frames",
                 "type": "number",
                 "minimum": 1,
-                "default": 100,
+                "default": int(self._get_dialog_box_param("number_of_frames")),
                 "widget": "textarea",
             },
             "detector_distance": {
@@ -131,7 +142,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
                 "type": "number",
                 "minimum": 0,  # TODO: get limits from distance PV
                 "maximum": 3000,  # TODO: get limits from distance PV
-                "default": round(actual_sample_detector_distance.get(), 2),
+                "default": float(self._get_dialog_box_param("detector_distance")),
                 "widget": "textarea",
             },
             "photon_energy": {
@@ -139,20 +150,20 @@ class ScreeningFlow(AbstractPrefectWorkflow):
                 "type": "number",
                 "minimum": 5,  # TODO: get limits from PV?
                 "maximum": 25,
-                "default": round(energy_master.get(), 2),
+                "default": float(self._get_dialog_box_param("photon_energy")),
                 "widget": "textarea",
             },
             "processing_pipeline": {
                 "title": "Data Processing Pipeline",
                 "type": "string",
                 "enum": ["dials", "fast_dp", "dials_and_fast_dp"],
-                "default": "fast_dp",
+                "default": self._get_dialog_box_param("processing_pipeline"),
             },
             "crystal_counter": {
                 "title": "Crystal ID",
                 "type": "number",
                 "minimum": 0,
-                "default": 0,
+                "default": int(self._get_dialog_box_param("crystal_counter")),
                 "widget": "textarea",
             },
         }

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
@@ -10,13 +10,13 @@ from mx3_beamline_library.devices.motors import actual_sample_detector_distance
 
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 
+from ..Resolution import Resolution
 from .abstract_flow import AbstractPrefectWorkflow
 from .prefect_client import MX3PrefectClient
 from .schemas.screening import (
     ScreeningDialogBox,
     ScreeningParams,
 )
-from ..Resolution import Resolution
 
 SCREENING_DEPLOYMENT_NAME = environ.get(
     "SCREENING_DEPLOYMENT_NAME", "mxcube-screening/plans"
@@ -46,7 +46,11 @@ class ScreeningFlow(AbstractPrefectWorkflow):
         # This is the payload we get from the UI"
         dialog_box_model = ScreeningDialogBox.parse_obj(dialog_box_parameters)
 
-        detector_distance = self._resolution_to_distance(dialog_box_model.resolution, energy=dialog_box_model.photon_energy)
+        detector_distance = self._resolution_to_distance(
+            dialog_box_model.resolution,
+            energy=dialog_box_model.photon_energy,
+            roi_mode="disabled",
+        )
 
         screening_params = ScreeningParams(
             omega_range=dialog_box_model.omega_range,
@@ -198,7 +202,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
                 "photon_energy",
                 "processing_pipeline",
                 "crystal_counter",
-                "transmission"
+                "transmission",
             ],
             "dialogName": "Screening Parameters",
         }

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
@@ -16,6 +16,7 @@ from .schemas.screening import (
     ScreeningDialogBox,
     ScreeningParams,
 )
+from ..Resolution import Resolution
 
 SCREENING_DEPLOYMENT_NAME = environ.get(
     "SCREENING_DEPLOYMENT_NAME", "mxcube-screening/plans"
@@ -25,8 +26,8 @@ ADD_DUMMY_PIN_TO_DB = environ.get("ADD_DUMMY_PIN_TO_DB", "false").lower() == "tr
 
 class ScreeningFlow(AbstractPrefectWorkflow):
 
-    def __init__(self, state):
-        super().__init__(state)
+    def __init__(self, state, resolution: Resolution):
+        super().__init__(state, resolution)
 
         self._collection_type = "screening"
 
@@ -45,15 +46,18 @@ class ScreeningFlow(AbstractPrefectWorkflow):
         # This is the payload we get from the UI"
         dialog_box_model = ScreeningDialogBox.parse_obj(dialog_box_parameters)
 
+        detector_distance = self._resolution_to_distance(dialog_box_model.resolution, energy=dialog_box_model.photon_energy)
+
         screening_params = ScreeningParams(
             omega_range=dialog_box_model.omega_range,
             exposure_time=dialog_box_model.exposure_time,
             number_of_passes=1,
             count_time=None,
             number_of_frames=dialog_box_model.number_of_frames,
-            detector_distance=dialog_box_model.detector_distance / 1000,  # meters
+            detector_distance=detector_distance,
             photon_energy=dialog_box_model.photon_energy,
-            transmission=transmission.get(),
+            # Convert transmission percentage to a value between 0 and 1
+            transmission=dialog_box_model.transmission / 100,
             beam_size=(80, 80),  # TODO: get beam size
         )
 
@@ -136,12 +140,12 @@ class ScreeningFlow(AbstractPrefectWorkflow):
                 "default": int(self._get_dialog_box_param("number_of_frames")),
                 "widget": "textarea",
             },
-            "detector_distance": {
-                "title": "Detector Distance [mm]",
+            "resolution": {
+                "title": "Resolution [A]",
                 "type": "number",
                 "minimum": 0,  # TODO: get limits from distance PV
                 "maximum": 3000,  # TODO: get limits from distance PV
-                "default": float(self._get_dialog_box_param("detector_distance")),
+                "default": float(self._get_dialog_box_param("resolution")),
                 "widget": "textarea",
             },
             "photon_energy": {
@@ -150,6 +154,14 @@ class ScreeningFlow(AbstractPrefectWorkflow):
                 "minimum": 5,  # TODO: get limits from PV?
                 "maximum": 25,
                 "default": float(self._get_dialog_box_param("photon_energy")),
+                "widget": "textarea",
+            },
+            "transmission": {
+                "title": "Transmission [%]",
+                "type": "number",
+                "minimum": 0,  # TODO: get limits from PV?
+                "maximum": 100,
+                "default": float(self._get_dialog_box_param("transmission")),
                 "widget": "textarea",
             },
             "processing_pipeline": {
@@ -182,10 +194,11 @@ class ScreeningFlow(AbstractPrefectWorkflow):
                 "exposure_time",
                 "omega_range",
                 "number_of_frames",
-                "detector_distance",
+                "resolution",
                 "photon_energy",
                 "processing_pipeline",
                 "crystal_counter",
+                "transmission"
             ],
             "dialogName": "Screening Parameters",
         }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mxcubecore"
-version = "1.195.0.10"
+version = "1.195.0.11"
 license = "LGPL-3.0-or-later"
 description = "Core libraries for the MXCuBE application"
 authors = ["The MXCuBE collaboration <mxcube@esrf.fr>"]


### PR DESCRIPTION
* Remember collection parameters between collections. This is done by saving the collection parameters for `grid scans`, `screening` and `full dataset` collections in redis
* Adds a `default_params.yml` file to set default data collection parameters
* Removed `hardware_trigger` from the dialog box schema as is no longer needed 