### PR TITLE
display live data and multiple bug fixes

### DIFF
--- a/mxcubecore/Command/RestApi.py
+++ b/mxcubecore/Command/RestApi.py
@@ -1,0 +1,202 @@
+import copy
+import logging
+
+import httpx
+
+from mxcubecore import Poller
+from mxcubecore.CommandContainer import (
+    ChannelObject,
+    CommandObject,
+)
+from mxcubecore.dispatcher import saferef
+
+
+class RestApiCommand(CommandObject):
+    """REST API Command"""
+
+    def __init__(self, name, base_url, username=None, args=None, **kwargs):
+        CommandObject.__init__(self, name, username, **kwargs)
+
+        self.base_url = base_url
+        self.read_value_from_response = kwargs.get("read_value_from_response", True)
+        self.pollers = {}
+        self.__value_changed_callback_ref = None
+        self.__timeout_callback_ref = None
+
+        if args is None:
+            self.arg_list = ()
+        else:
+            # not very nice...
+            args = str(args)
+            if not args.endswith(","):
+                args += ","
+            self.arg_list = eval("(" + args + ")")
+
+        if len(self.arg_list) > 1:
+            logging.getLogger("HWR").error(
+                "RestApiCommand: Only scalar arguments are supported."
+            )
+            return
+
+        logging.getLogger("HWR").debug(
+            "RestApiCommand: initialized with base_url %s", self.base_url
+        )
+
+    # def __call__(self, *args, **kwargs):
+    #     self.emit("commandBeginWaitReply", (str(self.name()),))
+
+    #     if len(args) > 0 and len(self.arg_list) > 0:
+    #         logging.getLogger("HWR").error(
+    #             "%s: cannot execute command with arguments when 'args' is defined from XML",
+    #             str(self.name()),
+    #         )
+    #         self.emit("commandFailed", (-1, str(self.name())))
+    #         return
+    #     elif len(args) == 0 and len(self.arg_list) > 0:
+    #         args = self.arg_list
+
+    #     try:
+    #         if len(args) == 0:
+    #             # Perform a GET request to retrieve the current value
+    #             response = httpx.get(urljoin(f"{self.base_url}/value"), timeout=5.0)
+    #             response.raise_for_status()
+    #             value = response.json() if self.read_as_str else response.text
+    #             self.emit("commandReplyArrived", (value, str(self.name())))
+    #             return value
+    #         else:
+    #             # Perform a POST or PUT request to set a new value
+    #             value = args[0]
+    #             response = httpx.post(
+    #                 f"{self.base_url}/value", json={"value": value}, timeout=5.0
+    #             )
+    #             response.raise_for_status()
+    #             self.emit("commandReplyArrived", (0, str(self.name())))
+    #             return 0
+    #     except httpx.RequestError as e:
+    #         logging.getLogger("HWR").error(
+    #             "%s: HTTP request error: %s", str(self.name()), str(e)
+    #         )
+    #     except httpx.HTTPStatusError as e:
+    #         logging.getLogger("HWR").error(
+    #             "%s: HTTP status error: %s", str(self.name()), str(e)
+    #         )
+    #     except Exception as e:
+    #         logging.getLogger("HWR").error(
+    #             "%s: an error occurred: %s", str(self.name()), str(e)
+    #         )
+
+    #     self.emit("commandFailed", (-1, str(self.name())))
+
+    def value_changed(self, value):
+        try:
+            callback = self.__value_changed_callback_ref()
+        except Exception:
+            pass
+        else:
+            if callback is not None:
+                callback(value)
+
+    def on_polling_error(self, exception, poller_id):
+        logging.getLogger("HWR").error(
+            "RestApiCommand: Polling error occurred: %s", str(exception)
+        )
+
+    def poll(
+        self,
+        polling_time=1000,
+        arguments_list=(),
+        value_changed_callback=None,
+        timeout_callback=None,
+        direct=True,
+        compare=True,
+    ):
+        self.__value_changed_callback_ref = saferef.safe_ref(value_changed_callback)
+
+        def poll_cmd():
+            try:
+                response = httpx.get(self.base_url, timeout=1)
+                response.raise_for_status()
+                return (
+                    response.json()["value"]
+                    if self.read_value_from_response
+                    else response.json()
+                )
+            except Exception as e:
+                logging.getLogger("HWR").error(
+                    "RestApiCommand: Polling error: %s", str(e)
+                )
+                return None
+
+        Poller.poll(
+            poll_cmd,
+            copy.deepcopy(arguments_list),
+            polling_time,
+            self.value_changed,
+            self.on_polling_error,
+            compare,
+        )
+
+    def stop_polling(self):
+        pass
+
+    def abort(self):
+        pass
+
+    def is_connected(self):
+        try:
+            response = httpx.get(self.base_url, timeout=1)
+            response.raise_for_status()
+            return True
+        except Exception:
+            return False
+
+    def get_value(self) -> str | int | float:
+        try:
+            response = httpx.get(self.base_url, timeout=1)
+            response.raise_for_status()
+            return (
+                response.json()["value"]
+                if self.read_value_from_response
+                else response.json()
+            )
+        except Exception as e:
+            logging.getLogger("HWR").error("RestApiCommand: Polling error: %s", str(e))
+            return None
+
+    def set_value(self, value) -> None:
+        try:
+            response = httpx.put(self.base_url, json={"value": value})
+            response.raise_for_status()
+        except Exception as e:
+            logging.getLogger("HWR").error("RestApiCommand: Polling error: %s", str(e))
+            return None
+
+
+class RestApiChannel(ChannelObject):
+    """Emulates a REST API channel with a RestApiCommand + polling"""
+
+    def __init__(
+        self, name, base_url, username=None, polling=None, args=None, **kwargs
+    ):
+        ChannelObject.__init__(self, name, username, **kwargs)
+        self.command = RestApiCommand(
+            name + "_internalCmd", base_url, username, args, **kwargs
+        )
+        try:
+            self.polling = int(polling)
+        except Exception:
+            self.polling = None
+
+        self.command.poll(self.polling, self.command.arg_list, self.value_changed)
+
+    def value_changed(self, value):
+        self.emit("update", value)
+
+    def get_value(self):
+        return self.command.get_value()
+
+    def set_value(self, value):
+        self.command.set_value(value)
+
+    def is_connected(self):
+        return self.command.is_connected()

--- a/mxcubecore/Command/RestApi.py
+++ b/mxcubecore/Command/RestApi.py
@@ -1,5 +1,8 @@
-import copy
 import logging
+from typing import (
+    Any,
+    Callable,
+)
 
 import httpx
 
@@ -12,82 +15,42 @@ from mxcubecore.dispatcher import saferef
 
 
 class RestApiCommand(CommandObject):
-    """REST API Command"""
+    """
+    A REST API Command class for polling and interacting with REST APIs, e.g.
+    the Dectris SIMPLON API
+    """
 
-    def __init__(self, name, base_url, username=None, args=None, **kwargs):
+    def __init__(self, name: str, url: str, username: str | None, **kwargs):
+        """
+        Parameters
+        ----------
+        name : str
+            The name of the Command object
+        url : str
+            The full url, e.g. "http://localhost:8000/detector/api/1.8.0/status/state"
+        username : str | None, optional
+            The username, by default None
+        """
         CommandObject.__init__(self, name, username, **kwargs)
 
-        self.base_url = base_url
+        self.url = url
         self.read_value_from_response = kwargs.get("read_value_from_response", True)
         self.pollers = {}
         self.__value_changed_callback_ref = None
-        self.__timeout_callback_ref = None
-
-        if args is None:
-            self.arg_list = ()
-        else:
-            # not very nice...
-            args = str(args)
-            if not args.endswith(","):
-                args += ","
-            self.arg_list = eval("(" + args + ")")
-
-        if len(self.arg_list) > 1:
-            logging.getLogger("HWR").error(
-                "RestApiCommand: Only scalar arguments are supported."
-            )
-            return
 
         logging.getLogger("HWR").debug(
-            "RestApiCommand: initialized with base_url %s", self.base_url
+            "RestApiCommand: initialized with url %s", self.url
         )
 
-    # def __call__(self, *args, **kwargs):
-    #     self.emit("commandBeginWaitReply", (str(self.name()),))
+    def value_changed(self, value: Any):
+        """
+        Calls the callback function when the value changes.
 
-    #     if len(args) > 0 and len(self.arg_list) > 0:
-    #         logging.getLogger("HWR").error(
-    #             "%s: cannot execute command with arguments when 'args' is defined from XML",
-    #             str(self.name()),
-    #         )
-    #         self.emit("commandFailed", (-1, str(self.name())))
-    #         return
-    #     elif len(args) == 0 and len(self.arg_list) > 0:
-    #         args = self.arg_list
-
-    #     try:
-    #         if len(args) == 0:
-    #             # Perform a GET request to retrieve the current value
-    #             response = httpx.get(urljoin(f"{self.base_url}/value"), timeout=5.0)
-    #             response.raise_for_status()
-    #             value = response.json() if self.read_as_str else response.text
-    #             self.emit("commandReplyArrived", (value, str(self.name())))
-    #             return value
-    #         else:
-    #             # Perform a POST or PUT request to set a new value
-    #             value = args[0]
-    #             response = httpx.post(
-    #                 f"{self.base_url}/value", json={"value": value}, timeout=5.0
-    #             )
-    #             response.raise_for_status()
-    #             self.emit("commandReplyArrived", (0, str(self.name())))
-    #             return 0
-    #     except httpx.RequestError as e:
-    #         logging.getLogger("HWR").error(
-    #             "%s: HTTP request error: %s", str(self.name()), str(e)
-    #         )
-    #     except httpx.HTTPStatusError as e:
-    #         logging.getLogger("HWR").error(
-    #             "%s: HTTP status error: %s", str(self.name()), str(e)
-    #         )
-    #     except Exception as e:
-    #         logging.getLogger("HWR").error(
-    #             "%s: an error occurred: %s", str(self.name()), str(e)
-    #         )
-
-    #     self.emit("commandFailed", (-1, str(self.name())))
-
-    def value_changed(self, value):
+        Parameters
+        ----------
+        value : Any
+            The new value to be passed to the callback function.
+        """
         try:
             callback = self.__value_changed_callback_ref()
         except Exception:
@@ -96,40 +59,75 @@ class RestApiCommand(CommandObject):
             if callback is not None:
                 callback(value)
 
-    def on_polling_error(self, exception, poller_id):
+    def on_polling_error(self, exception: Exception, poller_id: int) -> None:
+        """
+        Handles errors that occur during polling.
+
+        Parameters
+        ----------
+        exception : Exception
+            The exception that occurred during polling.
+        poller_id : int
+            The ID of the poller that encountered the error.
+        """
         logging.getLogger("HWR").error(
             "RestApiCommand: Polling error occurred: %s", str(exception)
         )
 
+    def _poll_cmd(self) -> Any:
+        """
+        Executes a polling command by sending an HTTP request to self.url
+
+        Returns
+        -------
+        Any
+            The value from the JSON response if `read_value_from_response`
+            is True, otherwise the entire JSON response. Returns None if an
+            error occurs
+        """
+
+        try:
+            response = httpx.get(self.url, timeout=1)
+            response.raise_for_status()
+            return (
+                response.json()["value"]
+                if self.read_value_from_response
+                else response.json()
+            )
+        except Exception as e:
+            logging.getLogger("HWR").error("RestApiCommand: Polling error: %s", str(e))
+            return None
+
     def poll(
         self,
-        polling_time=1000,
-        arguments_list=(),
-        value_changed_callback=None,
-        timeout_callback=None,
-        direct=True,
-        compare=True,
+        polling_time: int = 1000,
+        value_changed_callback: Callable | None = None,
+        timeout_callback: Callable | None = None,
+        direct: bool = True,
+        compare: bool = True,
     ):
+        """
+        Starts polling the REST API endpoint
+
+        Parameters
+        ----------
+        polling_time : int, optional
+            The polling interval, by default 1000.
+        value_changed_callback : Callable, optional
+            A callback function to be called when the polled value changes, by default None.
+        timeout_callback : Callable, optional
+            A callback function to be called on timeout, by default None.
+        direct : bool, optional
+            Whether to directly call the callback, by default True.
+        compare : bool, optional
+            Whether to compare the new and old value before calling the callback,
+            by default True.
+        """
         self.__value_changed_callback_ref = saferef.safe_ref(value_changed_callback)
 
-        def poll_cmd():
-            try:
-                response = httpx.get(self.base_url, timeout=1)
-                response.raise_for_status()
-                return (
-                    response.json()["value"]
-                    if self.read_value_from_response
-                    else response.json()
-                )
-            except Exception as e:
-                logging.getLogger("HWR").error(
-                    "RestApiCommand: Polling error: %s", str(e)
-                )
-                return None
-
         Poller.poll(
-            poll_cmd,
-            copy.deepcopy(arguments_list),
+            self._poll_cmd,
+            (),
             polling_time,
             self.value_changed,
             self.on_polling_error,
@@ -137,22 +135,45 @@ class RestApiCommand(CommandObject):
         )
 
     def stop_polling(self):
+        """
+        Stops polling
+        """
         pass
 
     def abort(self):
+        """
+        Aborts the current operation.
+        """
         pass
 
-    def is_connected(self):
+    def is_connected(self) -> bool:
+        """
+        Checks if the REST API endpoint is connected
+
+        Returns
+        -------
+        bool
+            True if the endpoint is connected, False otherwise
+        """
         try:
-            response = httpx.get(self.base_url, timeout=1)
+            response = httpx.get(self.url, timeout=1)
             response.raise_for_status()
             return True
         except Exception:
             return False
 
-    def get_value(self) -> str | int | float:
+    def get_value(self) -> Any:
+        """
+        Retrieves the current value from the REST API endpoint.
+
+        Returns
+        -------
+        Any
+            The value from the JSON response if `read_value_from_response` is True,
+            otherwise the entire JSON response. Returns None if an error occurs
+        """
         try:
-            response = httpx.get(self.base_url, timeout=1)
+            response = httpx.get(self.url, timeout=1)
             response.raise_for_status()
             return (
                 response.json()["value"]
@@ -164,8 +185,16 @@ class RestApiCommand(CommandObject):
             return None
 
     def set_value(self, value) -> None:
+        """
+        Sets a new value on the REST API endpoint
+
+        Parameters
+        ----------
+        value : Any
+            The new value to set on the endpoint
+        """
         try:
-            response = httpx.put(self.base_url, json={"value": value})
+            response = httpx.put(self.url, json={"value": value})
             response.raise_for_status()
         except Exception as e:
             logging.getLogger("HWR").error("RestApiCommand: Polling error: %s", str(e))
@@ -173,30 +202,79 @@ class RestApiCommand(CommandObject):
 
 
 class RestApiChannel(ChannelObject):
-    """Emulates a REST API channel with a RestApiCommand + polling"""
+    """
+    A REST API Channel class for polling and interacting with the Dectris SIMPLON API
+    """
 
     def __init__(
-        self, name, base_url, username=None, polling=None, args=None, **kwargs
+        self,
+        name: str,
+        url: str,
+        username: str | None = None,
+        polling: int | float | None = None,
+        **kwargs
     ):
+        """
+        Parameters
+        ----------
+        name : str
+            The name of the Command object
+        url : str
+            The full url, e.g. "http://localhost:8000/detector/api/1.8.0/status/state"
+        username : str | None, optional
+            The username, by default None
+        polling: int | float | None = None
+            The polling interval in milliseconds
+        """
         ChannelObject.__init__(self, name, username, **kwargs)
-        self.command = RestApiCommand(
-            name + "_internalCmd", base_url, username, args, **kwargs
-        )
+        self.command = RestApiCommand(name + "_internalCmd", url, username, **kwargs)
         try:
             self.polling = int(polling)
         except Exception:
             self.polling = None
 
-        self.command.poll(self.polling, self.command.arg_list, self.value_changed)
+        self.command.poll(self.polling, self.value_changed)
 
-    def value_changed(self, value):
+    def value_changed(self, value: Any):
+        """
+        Emits an update signal when the value changes
+
+        Parameters
+        ----------
+        value : Any
+            The new value to emit
+        """
         self.emit("update", value)
 
-    def get_value(self):
+    def get_value(self) -> Any:
+        """
+        Retrieves the current value from the REST API command
+
+        Returns
+        -------
+        Any
+            The current value obtained from self.url
+        """
         return self.command.get_value()
 
-    def set_value(self, value):
+    def set_value(self, value) -> None:
+        """
+        Sets a new value on the REST API command
+
+        Parameters
+        ----------
+        value : Any
+            The new value to set on self.url
+        """
         self.command.set_value(value)
 
-    def is_connected(self):
+    def is_connected(self) -> bool:
+        """
+        Checks if the REST API command is connected
+
+        Returns
+        -------
+        bool
+            True if the REST API command is connected, False otherwise
+        """
         return self.command.is_connected()

--- a/mxcubecore/CommandContainer.py
+++ b/mxcubecore/CommandContainer.py
@@ -538,6 +538,24 @@ class CommandContainer:
                     channel_name,
                 )
 
+        elif channel_type.lower() == "rest_api":
+            if "default_value" not in attributes_dict:
+                try:
+                    attributes_dict["default_value"] = float(self.default_value)
+                except AttributeError:
+                    pass
+
+            try:
+                from mxcubecore.Command.RestApi import RestApiChannel
+
+                new_channel = RestApiChannel(channel_name, channel, **attributes_dict)
+            except Exception:
+                logging.getLogger("HWR").exception(
+                    "%s: cannot add rest_api channel %s (hint: check attributes)",
+                    self.name(),
+                    channel_name,
+                )
+
         if new_channel is not None:
             if channel_on_change is not None:
                 new_channel._on_change = (channel_on_change, weakref.ref(self))
@@ -902,6 +920,18 @@ class CommandContainer:
             except Exception:
                 logging.getLogger().exception(
                     '%s: could not add command "%s" (hint: check command attributes)',
+                    self.name(),
+                    cmd_name,
+                )
+
+        elif cmd_type.lower() == "rest_api":
+            try:
+                from mxcubecore.Command.RestApi import RestApiCommand
+
+                new_command = RestApiCommand(cmd_name, cmd, **attributes_dict)
+            except Exception:
+                logging.getLogger().exception(
+                    '%s: could not add rest_api command "%s" (hint: check command attributes)',
                     self.name(),
                     cmd_name,
                 )

--- a/mxcubecore/HardwareObjects/ANSTO/Detector.py
+++ b/mxcubecore/HardwareObjects/ANSTO/Detector.py
@@ -1,14 +1,12 @@
 import ast
-from os import getenv
 from typing import Literal
 from urllib.parse import urljoin
 
 from httpx import Client
 
 from mxcubecore.BaseHardwareObjects import HardwareObjectState
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.abstract.AbstractDetector import AbstractDetector
-
-SIMPLON_API = getenv("SIMPLON_API", "http://localhost:8000")
 
 
 class Detector(AbstractDetector):
@@ -24,7 +22,6 @@ class Detector(AbstractDetector):
         Descript. :
         """
         AbstractDetector.__init__(self, name)
-        self.simplon_api = SIMPLON_API
         self._state = HardwareObjectState.READY
         self.simplon_state_to_hw_obj_state = {
             "error": HardwareObjectState.FAULT,
@@ -83,7 +80,7 @@ class Detector(AbstractDetector):
                 "name": "state",
                 "polling": 2000,
             },
-            urljoin(SIMPLON_API, "/detector/api/1.8.0/status/state"),
+            urljoin(settings.SIMPLON_API, "/detector/api/1.8.0/status/state"),
         )
         self.state.connect_signal("update", self._update_state)
 
@@ -111,7 +108,7 @@ class Detector(AbstractDetector):
     def _get_detector_config(self, parameter):
         with Client() as client:
             response = client.get(
-                urljoin(SIMPLON_API, f"/detector/api/1.8.0/config/{parameter}")
+                urljoin(settings.SIMPLON_API, f"/detector/api/1.8.0/config/{parameter}")
             )
             response.raise_for_status()
 
@@ -121,7 +118,7 @@ class Detector(AbstractDetector):
         try:
             with Client() as client:
                 response = client.get(
-                    urljoin(SIMPLON_API, "/detector/api/1.8.0/status/state")
+                    urljoin(settings.SIMPLON_API, "/detector/api/1.8.0/status/state")
                 )
             if response.status_code != 200:
                 return HardwareObjectState.FAULT

--- a/mxcubecore/HardwareObjects/ANSTO/Detector.py
+++ b/mxcubecore/HardwareObjects/ANSTO/Detector.py
@@ -1,5 +1,4 @@
 import ast
-import logging
 from os import getenv
 from typing import Literal
 from urllib.parse import urljoin
@@ -61,7 +60,7 @@ class Detector(AbstractDetector):
             self._get_detector_config("beam_center_y"),
         )
 
-        if self._beam_centre == (0,0):
+        if self._beam_centre == (0, 0):
             raise ValueError(
                 "The beam centre has not been set via the SIMPLON API. "
                 "Ensure 'beam_center_x' and 'beam_center_y' are different from zero"

--- a/mxcubecore/HardwareObjects/ANSTO/Diffractometer.py
+++ b/mxcubecore/HardwareObjects/ANSTO/Diffractometer.py
@@ -4,8 +4,6 @@ import logging
 import random
 import time
 import warnings
-from distutils.util import strtobool
-from os import getenv
 from typing import Tuple
 
 import gevent
@@ -32,11 +30,6 @@ EXPORTER_TO_HWOBJ_STATE = {
     "Unknown": HardwareObjectState.BUSY,
     "Offline": HardwareObjectState.OFF,
 }
-USE_TOP_CAMERA = strtobool(getenv("USE_TOP_CAMERA", "true"))
-CALIBRATED_ALIGNMENT_Z = float(getenv("CALIBRATED_ALIGNMENT_Z", "0.487"))
-SAMPLE_CENTERING_PREFECT_DEPLOYMENT_NAME = getenv(
-    "SAMPLE_CENTERING_PREFECT_DEPLOYMENT_NAME", "mxcube-sample-centering/plans"
-)
 
 
 class Diffractometer(GenericDiffractometer):
@@ -311,12 +304,12 @@ class Diffractometer(GenericDiffractometer):
         # beam_size_micrometers = tuple([b * 1000 for b in self.beam.get_beam_size()])
         try:
             sample_centering = MX3PrefectClient(
-                name=SAMPLE_CENTERING_PREFECT_DEPLOYMENT_NAME,
+                name=settings.SAMPLE_CENTERING_PREFECT_DEPLOYMENT_NAME,
                 parameters={
                     "sample_id": "test",
                     "beam_position": [self.beam_position[0], self.beam_position[1]],
-                    "use_top_camera": USE_TOP_CAMERA,
-                    "calibrated_alignment_z": CALIBRATED_ALIGNMENT_Z,
+                    "use_top_camera": settings.USE_TOP_CAMERA,
+                    "calibrated_alignment_z": settings.CALIBRATED_ALIGNMENT_Z,
                 },
             )
             # NOTE: using asyncio.run() does not seem to work consistently

--- a/mxcubecore/HardwareObjects/ANSTO/Diffractometer.py
+++ b/mxcubecore/HardwareObjects/ANSTO/Diffractometer.py
@@ -16,6 +16,7 @@ from scipy import optimize
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObjectState
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.GenericDiffractometer import (
     GenericDiffractometer,
     PhaseEnum,
@@ -45,7 +46,7 @@ class Diffractometer(GenericDiffractometer):
 
     def __init__(self, *args) -> None:
         GenericDiffractometer.__init__(self, *args)
-        self.exporter_addr = getenv("EXPORTER_ADDRESS", "12.345.678.10:1234")
+        self.exporter_addr = settings.EXPORTER_ADDRESS
 
     def init(self) -> None:
         """

--- a/mxcubecore/HardwareObjects/ANSTO/ExporterMotor.py
+++ b/mxcubecore/HardwareObjects/ANSTO/ExporterMotor.py
@@ -1,7 +1,6 @@
 import logging
 import math
 import sys
-from os import getenv
 
 from gevent import (
     Timeout,
@@ -10,6 +9,7 @@ from gevent import (
 
 from mxcubecore.Command.Exporter import Exporter
 from mxcubecore.Command.exporter.ExporterStates import ExporterStates
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.abstract.AbstractMotor import AbstractMotor
 
 
@@ -57,7 +57,7 @@ class ExporterMotor(AbstractMotor):
         self._motor_pos_suffix = self.get_property("position_suffix", "Position")
         self._motor_state_suffix = self.get_property("state_suffix", "State")
 
-        self._exporter_address = getenv("EXPORTER_ADDRESS", "12.345.678.91:1234")
+        self._exporter_address = settings.EXPORTER_ADDRESS
         _host, _port = self._exporter_address.split(":")
         self._exporter = Exporter(_host, int(_port))
 

--- a/mxcubecore/HardwareObjects/ANSTO/ExporterNState.py
+++ b/mxcubecore/HardwareObjects/ANSTO/ExporterNState.py
@@ -65,6 +65,11 @@ class ExporterNState(AbstractNState):
         self.state_channel.connect_signal("update", self._update_state)
         self.update_state()
 
+    def update_value(self, value=None):
+        if self._nominal_value != value:
+            self._nominal_value = value
+            self.emit("valueChanged", (self.value_to_enum(value),))
+
     def _wait_hardware(self, value, timeout=None):
         """Wait timeout seconds till hardware in place.
         Args:

--- a/mxcubecore/HardwareObjects/ANSTO/ExporterNState.py
+++ b/mxcubecore/HardwareObjects/ANSTO/ExporterNState.py
@@ -65,10 +65,12 @@ class ExporterNState(AbstractNState):
         self.state_channel.connect_signal("update", self._update_state)
         self.update_state()
 
-    def update_value(self, value=None):
-        if self._nominal_value != value:
-            self._nominal_value = value
-            self.emit("valueChanged", (self.value_to_enum(value),))
+    def update_value(self, value: bool | None = None):
+        if value is not None:
+            if isinstance(value, bool):
+                self.emit("valueChanged", (self.value_to_enum(value),))
+            else:
+                self.emit("valueChanged", (value,))
 
     def _wait_hardware(self, value, timeout=None):
         """Wait timeout seconds till hardware in place.
@@ -147,6 +149,7 @@ class ExporterNState(AbstractNState):
             self._wait_hardware(value, 120)
         self._wait_ready(120)
         self.update_state(self.STATES.READY)
+        self.update_value(self.get_value())
 
     def get_value(self):
         """Get the device value

--- a/mxcubecore/HardwareObjects/ANSTO/ExporterNState.py
+++ b/mxcubecore/HardwareObjects/ANSTO/ExporterNState.py
@@ -1,5 +1,4 @@
 from enum import Enum
-from os import getenv
 
 from gevent import (
     Timeout,
@@ -8,6 +7,7 @@ from gevent import (
 
 from mxcubecore.Command.Exporter import Exporter
 from mxcubecore.Command.exporter.ExporterStates import ExporterStates
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.abstract.AbstractNState import AbstractNState
 
 
@@ -39,7 +39,7 @@ class ExporterNState(AbstractNState):
         self.use_value_as_state = self.get_property("value_state")
         state_channel = self.get_property("state_channel_name", "State")
 
-        _exporter_address = getenv("EXPORTER_ADDRESS", "12.345.678.10:1234")
+        _exporter_address = settings.EXPORTER_ADDRESS
         _host, _port = _exporter_address.split(":")
         self._exporter = Exporter(_host, int(_port))
 

--- a/mxcubecore/HardwareObjects/ANSTO/MachineInfo.py
+++ b/mxcubecore/HardwareObjects/ANSTO/MachineInfo.py
@@ -2,12 +2,36 @@ import gevent
 from mx3_beamline_library.devices.beam import ring_current
 
 from mxcubecore import HardwareRepository as HWR
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.abstract.AbstractMachineInfo import AbstractMachineInfo
 
 
 class MachineInfo(AbstractMachineInfo):
     def init(self):
         super().init()
+
+        if settings.BL_ACTIVE:
+            # The following channels is used to poll ring_current PV
+            self.ring_current_channel = self.add_channel(
+                {
+                    "type": "epics",
+                    "name": "ring_current",
+                    "polling": 1000,  # milliseconds
+                },
+                ring_current.pvname,
+            )
+            self.ring_current_channel.connect_signal("update", self._value_changed)
+
+    def _value_changed(self, value: float | None) -> None:
+        """Emits a valueChanged signal. Used by self.ring_current_channel
+
+        Parameters
+        ----------
+        value : float | None
+            The ring current value
+        """
+        self._value = value
+        self.emit("valueChanged", self._value)
 
     def get_current(self) -> float:
         """Gets the ring current"""

--- a/mxcubecore/HardwareObjects/ANSTO/MicrodiffCamera.py
+++ b/mxcubecore/HardwareObjects/ANSTO/MicrodiffCamera.py
@@ -6,6 +6,7 @@ from threading import Thread
 import gevent
 
 from mxcubecore.BaseHardwareObjects import HardwareObject
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.ANSTO.redis_client import RedisClient
 
 
@@ -72,11 +73,10 @@ class MicrodiffCamera(HardwareObject):
         -------
         None
         """
-        MD3_REDIS_HOST = os.environ.get("MD3_REDIS_HOST", "12.345.678.90")
-        MD3_REDIS_PORT = int(os.environ.get("MD3_REDIS_PORT", "6379"))
+
         default_args = {
-            "host": MD3_REDIS_HOST,
-            "port": MD3_REDIS_PORT,
+            "host": settings.MD3_REDIS_HOST,
+            "port": settings.MD3_REDIS_PORT,
             "hybrid": "bzoom",
             "first": "acA2500-x5",
             "second": "acA2440-x30",

--- a/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/PrefectWorkflow.py
@@ -13,6 +13,7 @@ from gevent.event import Event
 
 from mxcubecore import HardwareRepository as HWR
 from mxcubecore.BaseHardwareObjects import HardwareObject
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.SampleView import SampleView
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 
@@ -113,12 +114,6 @@ class PrefectWorkflow(HardwareObject):
         self.gevent_event = None
         self.workflow_name = None
 
-        self.REDIS_HOST = os.environ.get("MXCUBE_REDIS_HOST", "localhost")
-        self.REDIS_PORT = int(os.environ.get("MXCUBE_REDIS_PORT", "6379"))
-        self.REDIS_USERNAME = os.environ.get("MXCUBE_REDIS_USERNAME", None)
-        self.REDIS_PASSWORD = os.environ.get("MXCUBE_REDIS_PASSWORD", None)
-        self.REDIS_DB = int(os.environ.get("MXCUBE_REDIS_DB", "0"))
-
         self.mxcubecore_workflow_aborted = False
 
     def _init(self) -> None:
@@ -146,11 +141,11 @@ class PrefectWorkflow(HardwareObject):
         self.resolution: Resolution = hwr.get_hardware_object("/resolution")
 
         self.redis_connection = redis.StrictRedis(
-            host=self.REDIS_HOST,
-            port=self.REDIS_PORT,
-            username=self.REDIS_USERNAME,
-            password=self.REDIS_PASSWORD,
-            db=self.REDIS_DB,
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            username=settings.REDIS_USERNAME,
+            password=settings.REDIS_PASSWORD,
+            db=settings.REDIS_DB,
         )
 
         self._save_default_collection_params_to_redis()

--- a/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
+++ b/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
@@ -4,7 +4,6 @@ import logging  # noqa: E402
 from asyncio import new_event_loop as asyncio_new_event_loop
 from asyncio import set_event_loop as asyncio_set_event_loop  # noqa: E402
 from functools import lru_cache  # noqa: E402
-from os import getenv
 from time import time  # noqa: E402
 from typing import (  # noqa: E402
     Any,
@@ -27,6 +26,7 @@ from typing_extensions import (  # noqa: E402
     TypedDict,
 )
 
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.abstract.AbstractSampleChanger import (  # noqa: E402
     SampleChanger as AbstractSampleChanger,
 )
@@ -46,8 +46,6 @@ from .prefect_flows.prefect_client import MX3PrefectClient  # noqa: E402
 
 hwr_logger = logging.getLogger("HWR")
 robot_config = get_robot_settings()
-
-ROBOT_HOST = getenv("ROBOT_HOST", "127.0.0.0")
 
 
 class SampleChangerError(Exception):
@@ -121,8 +119,12 @@ class SampleChanger(AbstractSampleChanger):
         self._selected_basket = -1
         self._scIsCharging = None
 
-        self.no_of_baskets = robot_config.ASC_NUM_PUCKS
-        self.no_of_samples_in_basket = robot_config.ASC_NUM_PINS
+        self.no_of_baskets = (
+            robot_config.ASC_NUM_PUCKS
+        )  # TODO: no_of_baskets = number of projects
+        self.no_of_samples_in_basket = (
+            robot_config.ASC_NUM_PINS
+        )  # TODO: number of samples per project
 
         for _puck_id in range(1, self.no_of_baskets + 1):
             basket = Puck(
@@ -171,7 +173,7 @@ class SampleChanger(AbstractSampleChanger):
         """Cache the client, this allows the client to be used in dependencies and
         for overwriting in tests
         """
-        return Client(host=ROBOT_HOST, readonly=False)
+        return Client(host=settings.ROBOT_HOST, readonly=False)
 
     def get_log_filename(self):
         return self.log_filename

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
@@ -1,13 +1,6 @@
 import asyncio
 import logging
 
-import redis
-from mx3_beamline_library.devices.beam import (
-    energy_master,
-    transmission,
-)
-from mx3_beamline_library.devices.motors import actual_sample_detector_distance
-
 from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
@@ -8,11 +8,6 @@ import numpy as np
 import numpy.typing as npt
 import redis
 import redis.asyncio
-from mx3_beamline_library.devices.beam import (
-    energy_master,
-    transmission,
-)
-from mx3_beamline_library.devices.motors import actual_sample_detector_distance
 
 from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.SampleView import (

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
@@ -1,7 +1,6 @@
 import asyncio
 import logging
 import pickle
-from os import environ
 from typing import Union
 
 import matplotlib.pyplot as plt
@@ -15,6 +14,7 @@ from mx3_beamline_library.devices.beam import (
 )
 from mx3_beamline_library.devices.motors import actual_sample_detector_distance
 
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.SampleView import (
     Grid,
     SampleView,
@@ -28,17 +28,6 @@ from .schemas.grid_scan import (
     GridScanDialogBox,
     GridScanParams,
 )
-
-GRID_SCAN_DEPLOYMENT_NAME = environ.get(
-    "GRID_SCAN_DEPLOYMENT_NAME", "mxcube-grid-scan/plans"
-)
-_number_of_processes = environ.get("GRID_SCAN_NUMBER_OF_PROCESSES", None)
-if _number_of_processes is not None:
-    GRID_SCAN_NUMBER_OF_PROCESSES = int(_number_of_processes)
-else:
-    GRID_SCAN_NUMBER_OF_PROCESSES = None
-
-ADD_DUMMY_PIN_TO_DB = environ.get("ADD_DUMMY_PIN_TO_DB", "false").lower() == "true"
 
 
 class GridScanFlow(AbstractPrefectWorkflow):
@@ -90,7 +79,7 @@ class GridScanFlow(AbstractPrefectWorkflow):
 
         dialog_box_model = GridScanDialogBox.model_validate(dialog_box_parameters)
 
-        if not ADD_DUMMY_PIN_TO_DB:
+        if not settings.ADD_DUMMY_PIN_TO_DB:
             logging.getLogger("HWR").info("Getting pin from the data layer...")
             pin = self.get_pin_model_of_mounted_sample_from_db()
             logging.getLogger("HWR").info(f"Mounted pin: {pin}")
@@ -131,7 +120,7 @@ class GridScanFlow(AbstractPrefectWorkflow):
             omega_range=dialog_box_model.omega_range,
             md3_alignment_y_speed=dialog_box_model.md3_alignment_y_speed,
             hardware_trigger=True,
-            number_of_processes=GRID_SCAN_NUMBER_OF_PROCESSES,
+            number_of_processes=settings.GRID_SCAN_NUMBER_OF_PROCESSES,
             # Convert transmission percentage to a value between 0 and 1
             transmission=dialog_box_model.transmission / 100,
         )
@@ -195,7 +184,7 @@ class GridScanFlow(AbstractPrefectWorkflow):
         """
 
         grid_scan_flow = MX3PrefectClient(
-            name=GRID_SCAN_DEPLOYMENT_NAME,
+            name=settings.GRID_SCAN_DEPLOYMENT_NAME,
             parameters=prefect_parameters.model_dump(exclude_none=True),
         )
 
@@ -212,11 +201,11 @@ class GridScanFlow(AbstractPrefectWorkflow):
             number_of_spots_array = np.zeros((num_rows, num_cols))
             resolution_array = np.zeros((num_rows, num_cols))
             async with redis.asyncio.StrictRedis(
-                host=self.REDIS_HOST,
-                port=self.REDIS_PORT,
-                username=self.REDIS_USERNAME,
-                password=self.REDIS_PASSWORD,
-                db=self.REDIS_DB,
+                host=settings.REDIS_HOST,
+                port=settings.REDIS_PORT,
+                username=settings.REDIS_USERNAME,
+                password=settings.REDIS_PASSWORD,
+                db=settings.REDIS_DB,
             ) as async_redis_client:
                 for _ in range(grid_size):
                     data, last_id = await self.read_message_from_redis_streams(

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/prefect_client.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/prefect_client.py
@@ -1,10 +1,7 @@
 import asyncio
 import logging
 from enum import StrEnum
-from os import (
-    environ,
-    path,
-)
+from urllib.parse import urljoin
 from uuid import UUID
 
 import redis
@@ -26,8 +23,6 @@ except ImportError:
     )
     FlowRunResponse = None
     State = None
-
-PREFECT_URI = environ.get("PREFECT_URI", "http://localhost:4200")
 
 
 class FlowState(StrEnum):
@@ -56,7 +51,7 @@ class MX3PrefectClient:
         self.flow_run_id = None
 
         self.deployment_id = None
-        self.prefect_client = PrefectClient(api=path.join(PREFECT_URI, "api"))
+        self.prefect_client = PrefectClient(api=urljoin(settings.PREFECT_URI, "api"))
 
         self.async_redis_connection = redis.asyncio.StrictRedis(
             host=settings.REDIS_HOST,

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/prefect_client.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/prefect_client.py
@@ -9,6 +9,8 @@ from uuid import UUID
 
 import redis
 
+from mxcubecore.configuration.ansto.config import settings
+
 try:
     # NOTE: State must be imported first,
     # otherwise the prefect client does not work properly
@@ -56,18 +58,12 @@ class MX3PrefectClient:
         self.deployment_id = None
         self.prefect_client = PrefectClient(api=path.join(PREFECT_URI, "api"))
 
-        REDIS_HOST = environ.get("MXCUBE_REDIS_HOST", "localhost")
-        REDIS_PORT = int(environ.get("MXCUBE_REDIS_PORT", "6379"))
-        REDIS_USERNAME = environ.get("MXCUBE_REDIS_USERNAME", None)
-        REDIS_PASSWORD = environ.get("MXCUBE_REDIS_PASSWORD", None)
-        REDIS_DB = int(environ.get("MXCUBE_REDIS_DB", "0"))
-
         self.async_redis_connection = redis.asyncio.StrictRedis(
-            host=REDIS_HOST,
-            port=REDIS_PORT,
-            username=REDIS_USERNAME,
-            password=REDIS_PASSWORD,
-            db=REDIS_DB,
+            host=settings.REDIS_HOST,
+            port=settings.REDIS_PORT,
+            username=settings.REDIS_USERNAME,
+            password=settings.REDIS_PASSWORD,
+            db=settings.REDIS_DB,
             decode_responses=True,
         )
 

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
@@ -1,12 +1,6 @@
 import asyncio
 import logging
 
-from mx3_beamline_library.devices.beam import (
-    energy_master,
-    transmission,
-)
-from mx3_beamline_library.devices.motors import actual_sample_detector_distance
-
 from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
@@ -1,6 +1,5 @@
 import asyncio
 import logging
-from os import environ
 
 from mx3_beamline_library.devices.beam import (
     energy_master,
@@ -8,6 +7,7 @@ from mx3_beamline_library.devices.beam import (
 )
 from mx3_beamline_library.devices.motors import actual_sample_detector_distance
 
+from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 
 from ..Resolution import Resolution
@@ -17,11 +17,6 @@ from .schemas.screening import (
     ScreeningDialogBox,
     ScreeningParams,
 )
-
-SCREENING_DEPLOYMENT_NAME = environ.get(
-    "SCREENING_DEPLOYMENT_NAME", "mxcube-screening/plans"
-)
-ADD_DUMMY_PIN_TO_DB = environ.get("ADD_DUMMY_PIN_TO_DB", "false").lower() == "true"
 
 
 class ScreeningFlow(AbstractPrefectWorkflow):
@@ -65,7 +60,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
             beam_size=(80, 80),  # TODO: get beam size
         )
 
-        if not ADD_DUMMY_PIN_TO_DB:
+        if not settings.ADD_DUMMY_PIN_TO_DB:
             pin = self.get_pin_model_of_mounted_sample_from_db()
             logging.getLogger("HWR").info(f"Mounted pin: {pin}")
             sample_id = pin.id
@@ -82,7 +77,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
             "screening_params": screening_params.dict(),
             "run_data_processing_pipeline": True,
             "hardware_trigger": True,
-            "add_dummy_pin": ADD_DUMMY_PIN_TO_DB,
+            "add_dummy_pin": settings.ADD_DUMMY_PIN_TO_DB,
             "pipeline": dialog_box_model.processing_pipeline,
             "data_processing_config": None,
         }
@@ -92,7 +87,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
         )
 
         screening_flow = MX3PrefectClient(
-            name=SCREENING_DEPLOYMENT_NAME, parameters=prefect_parameters
+            name=settings.SCREENING_DEPLOYMENT_NAME, parameters=prefect_parameters
         )
 
         # Remember the collection params for the next collection
@@ -183,7 +178,7 @@ class ScreeningFlow(AbstractPrefectWorkflow):
             },
         }
 
-        if ADD_DUMMY_PIN_TO_DB:
+        if settings.ADD_DUMMY_PIN_TO_DB:
             # Dev only
             properties["sample_id"] = {
                 "title": "Sample id (dev only)",

--- a/mxcubecore/HardwareObjects/ANSTO/redis_client.py
+++ b/mxcubecore/HardwareObjects/ANSTO/redis_client.py
@@ -12,14 +12,11 @@ from PIL import (
     ImageOps,
 )
 
+from mxcubecore.configuration.ansto.config import settings
+
 INT, FLOAT, STRING = 0, 1, 2
 TYPE_IDX, IS_RANGE_IDX, IS_GLOBAL_IDX, TEST_VALUES_IDX = 0, 1, 2, 3
 parsers = {INT: int, FLOAT: float, STRING: None}
-
-# IP ADDRESS :
-MD_REDIS_HOST = os.environ.get("MD_REDIS_HOST", "12.345.678.90")
-MD_REDIS_PORT = int(os.environ.get("MD_REDIS_PORT", "6379"))
-IP = f"{MD_REDIS_HOST}:{MD_REDIS_PORT}"
 
 
 class RedisClient(redis.Redis):
@@ -92,15 +89,6 @@ class RedisClient(redis.Redis):
     pre_header = "# "
     post_header = " #"
     # ------------------
-    default_args = {
-        "host": IP,
-        "port": 6379,
-        "hybrid": "bzoom",
-        "first": "acA2500-x5",
-        "second": "acA2440-x30",
-        "capture": True,
-        "write_image": False,
-    }
 
     def __init__(self, args):
         redis.Redis.__init__(self, host=args["host"], port=args["port"], db=0)
@@ -541,8 +529,8 @@ class RedisClient(redis.Redis):
 
 if __name__ == "__main__":
     default_args = {
-        "host": "10.244.101.30",
-        "port": 6379,
+        "host": settings.MD3_REDIS_HOST,
+        "port": settings.MD3_REDIS_PORT,
         "hybrid": "bzoom",
         "first": "acA2500-x5",
         "second": "acA2440-x30",

--- a/mxcubecore/configuration/ansto/config.py
+++ b/mxcubecore/configuration/ansto/config.py
@@ -7,11 +7,14 @@ from pydantic_settings import BaseSettings
 
 
 class PrefectSettings(BaseSettings):
+    PREFECT_URI: str = Field("http://localhost:4200", env="PREFECT_URI")
     GRID_SCAN_DEPLOYMENT_NAME: str = Field(
         "mxcube-grid-scan/plans", env="GRID_SCAN_DEPLOYMENT_NAME"
     )
     GRID_SCAN_NUMBER_OF_PROCESSES: int | None = Field(
-        None, env="GRID_SCAN_NUMBER_OF_PROCESSES"
+        None,
+        env="GRID_SCAN_NUMBER_OF_PROCESSES",
+        description="Number of processes used to process grid scan frames",
     )
 
     FULL_DATASET_DEPLOYMENT_NAME: str = Field(
@@ -21,11 +24,19 @@ class PrefectSettings(BaseSettings):
     SCREENING_DEPLOYMENT_NAME: str = Field(
         "mxcube-screening/plans", env="SCREENING_DEPLOYMENT_NAME"
     )
+    SAMPLE_CENTERING_PREFECT_DEPLOYMENT_NAME: str = Field(
+        "mxcube-sample-centering/plans", env="SAMPLE_CENTERING_PREFECT_DEPLOYMENT_NAME"
+    )
+    USE_TOP_CAMERA: bool = Field(
+        True, env="USE_TOP_CAMERA", description="False only for development"
+    )
+    CALIBRATED_ALIGNMENT_Z: float = Field(0.487, env="CALIBRATED_ALIGNMENT_Z")
 
 
 class MD3(BaseSettings):
     MD3_REDIS_HOST: str = Field("127.0.0.0", env="MD3_REDIS_HOST")
     MD3_REDIS_PORT: int = Field("6379", env="MD3_REDIS_PORT")
+    EXPORTER_ADDRESS: str = Field("127.0.0.0:1234", env="EXPORTER_ADDRESS")
 
 
 class RedisSettings(BaseSettings):
@@ -48,8 +59,11 @@ class APIs(BaseSettings):
 class ANSTOConfig(APIs, Robot, RedisSettings, MD3, PrefectSettings):
     BL_ACTIVE: bool = Field(default=False, env="BL_ACTIVE")
     EPN_STRING: str = Field(default="my_epn", env="EPN_STRING")
-    ADD_DUMMY_PIN_TO_DB: bool = Field(default=False, env="ADD_DUMMY_PIN_TO_DB")
+    ADD_DUMMY_PIN_TO_DB: bool = Field(
+        default=False,
+        env="ADD_DUMMY_PIN_TO_DB",
+        description="True only for development",
+    )
 
 
 settings = ANSTOConfig()
-print(settings)

--- a/mxcubecore/configuration/ansto/config.py
+++ b/mxcubecore/configuration/ansto/config.py
@@ -1,0 +1,55 @@
+"""
+This file contains settings changed via environment variables only
+"""
+
+from pydantic import Field
+from pydantic_settings import BaseSettings
+
+
+class PrefectSettings(BaseSettings):
+    GRID_SCAN_DEPLOYMENT_NAME: str = Field(
+        "mxcube-grid-scan/plans", env="GRID_SCAN_DEPLOYMENT_NAME"
+    )
+    GRID_SCAN_NUMBER_OF_PROCESSES: int | None = Field(
+        None, env="GRID_SCAN_NUMBER_OF_PROCESSES"
+    )
+
+    FULL_DATASET_DEPLOYMENT_NAME: str = Field(
+        "mxcube-full-data-collection/plans", env="FULL_DATASET_DEPLOYMENT_NAME"
+    )
+
+    SCREENING_DEPLOYMENT_NAME: str = Field(
+        "mxcube-screening/plans", env="SCREENING_DEPLOYMENT_NAME"
+    )
+
+
+class MD3(BaseSettings):
+    MD3_REDIS_HOST: str = Field("127.0.0.0", env="MD3_REDIS_HOST")
+    MD3_REDIS_PORT: int = Field("6379", env="MD3_REDIS_PORT")
+
+
+class RedisSettings(BaseSettings):
+    REDIS_HOST: str = Field("localhost", env="MXCUBE_REDIS_HOST")
+    REDIS_PORT: int = Field("6379", env="MXCUBE_REDIS_PORT")
+    REDIS_USERNAME: str | None = Field(None, env="MXCUBE_REDIS_USERNAME")
+    REDIS_PASSWORD: str | None = Field(None, env="MXCUBE_REDIS_PASSWORD")
+    REDIS_DB: int = Field(0, env="MXCUBE_REDIS_DB")
+
+
+class Robot(BaseSettings):
+    ROBOT_HOST: str = Field(default="127.0.0.0", env="ROBOT_HOST")
+
+
+class APIs(BaseSettings):
+    DATA_LAYER_API: str = Field(default="http://0.0.0.0:8088", env="DATA_LAYER_API")
+    SIMPLON_API: str = Field(default="http://0.0.0.0:8000", env="SIMPLON_API")
+
+
+class ANSTOConfig(APIs, Robot, RedisSettings, MD3, PrefectSettings):
+    BL_ACTIVE: bool = Field(default=False, env="BL_ACTIVE")
+    EPN_STRING: str = Field(default="my_epn", env="EPN_STRING")
+    ADD_DUMMY_PIN_TO_DB: bool = Field(default=False, env="ADD_DUMMY_PIN_TO_DB")
+
+
+settings = ANSTOConfig()
+print(settings)

--- a/mxcubecore/configuration/ansto/md3/zoom.xml
+++ b/mxcubecore/configuration/ansto/md3/zoom.xml
@@ -4,6 +4,6 @@
   <state_channel_name>ZoomState</state_channel_name>
   <!-- if levels do not correspond to values -->
   <values>{"LEVEL1": 1, "LEVEL2": 2, "LEVEL3": 3, "LEVEL4": 4, "LEVEL5": 5, "LEVEL6": 6, "LEVEL7": 7}</values>
-  <pixels_per_mm_x>{"LEVEL1": 520.973, "LEVEL2": 622.790, "LEVEL3": 797.109, "LEVEL4": 1040.905, "LEVEL5": 5904.201, "LEVEL6": 5503.597, "LEVEL7": 8502.362}</pixels_per_mm_x>
-  <pixels_per_mm_y>{"LEVEL1": 520.973, "LEVEL2": 622.790, "LEVEL3": 797.109, "LEVEL4": 1040.905, "LEVEL5": 5904.201, "LEVEL6": 5503.597, "LEVEL7": 8502.362}</pixels_per_mm_y>
+  <pixels_per_mm_x>{"LEVEL1": 520.973, "LEVEL2": 622.790, "LEVEL3": 797.109, "LEVEL4": 1040.905, "LEVEL5": 4229.726, "LEVEL6": 5503.597, "LEVEL7": 8502.362}</pixels_per_mm_x>
+  <pixels_per_mm_y>{"LEVEL1": 520.973, "LEVEL2": 622.790, "LEVEL3": 797.109, "LEVEL4": 1040.905, "LEVEL5": 4229.726, "LEVEL6": 5503.597, "LEVEL7": 8502.362}</pixels_per_mm_y>
 </object>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mxcubecore"
-version = "1.195.0.11"
+version = "1.195.0.12"
 license = "LGPL-3.0-or-later"
 description = "Core libraries for the MXCuBE application"
 authors = ["The MXCuBE collaboration <mxcube@esrf.fr>"]


### PR DESCRIPTION
* Adds `RestApiCommand` and `RestApiChannel` to poll values from the `SIMPLON `api to display live data of the detector state.
* Added a `config.py` file to obtain environment variables via pydantic settings.
* Display live data of: `detector distance`, `transmission`, `detector`, `ring current`, `fast shutter`, `white beam shutter`, `mono shutter`, `cryo stream`, and `energy`.
* Fixes an issue where the white beam shutter and mono shutter would not change its value after changing the value through the UI.
* Fixes an issue where the fast shutter readback would disappear after triggering data collections or grid scans.
* Fixes an issue where the beam center was not changed as a function of detector `roi_mode`.
* Updates the `pixels_per_mm` value at zoom level 5.