### PR TITLE
Update redis payload

### DIFF
--- a/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
+++ b/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
@@ -290,14 +290,14 @@ class SampleChanger(AbstractSampleChanger):
             client = self.get_client()
 
             state_res = client.status.state
-            loaded_pucks: dict[int, RobotPuck] = {}
+            loaded_pucks_dict: dict[int, RobotPuck] = {}
             for robot_puck in self.loaded_pucks:
-                loaded_pucks[robot_puck.id] = robot_puck
+                loaded_pucks_dict[robot_puck.id] = robot_puck
 
             components: list[Puck] = self.get_components()
             for mxcube_puck_idx in range(self.no_of_baskets):
                 puck_id = mxcube_puck_idx + 1
-                robot_puck = loaded_pucks.get(puck_id)
+                robot_puck = loaded_pucks_dict.get(puck_id)
                 mxcube_puck = components[mxcube_puck_idx]
                 mxcube_puck._set_info(
                     present=robot_puck is not None,
@@ -314,32 +314,32 @@ class SampleChanger(AbstractSampleChanger):
                             puck=robot_puck,
                         )
 
-                    address = Pin.get_sample_address(puck_id, pin_id)
+                    address = Pin.get_sample_address(puck_id, pin_id) # e.g. "1:01"
                     mxcube_pin: Pin = self.get_component_by_address(address)
                     pin_datamatrix = f"matr{puck_id}_{pin_id}"
-                    if robot_pin is not None:
-                        mxcube_pin._name = str(robot_pin)
+                    if robot_pin is not None and robot_puck.name: # check also that barcode exists
+                        mxcube_pin._name = str(robot_pin) + "my sample" # This is where sample name is set!!
                         pin_datamatrix = str(robot_pin)
                     
-                    mxcube_pin._set_info(
-                        present=robot_puck is not None,
-                        id=pin_datamatrix,
-                        scanned=False,
-                    )
-                    loaded: bool = False
-                    if state_res.goni_pin is not None:
-                        loaded = (
-                            state_res.goni_pin.puck.id,
-                            state_res.goni_pin.id,
-                        ) == (
-                            puck_id,
-                            pin_id,
+                        mxcube_pin._set_info(
+                            present=robot_puck is not None,
+                            id=pin_datamatrix,
+                            scanned=False,
                         )
-                    mxcube_pin._set_loaded(
-                        loaded=loaded,
-                        has_been_loaded=mxcube_pin.has_been_loaded() or loaded,
-                    )
-                    mxcube_pin._set_holder_length(Pin.STD_HOLDERLENGTH)
+                        loaded: bool = False
+                        if state_res.goni_pin is not None:
+                            loaded = (
+                                state_res.goni_pin.puck.id,
+                                state_res.goni_pin.id,
+                            ) == (
+                                puck_id,
+                                pin_id,
+                            )
+                        mxcube_pin._set_loaded(
+                            loaded=loaded,
+                            has_been_loaded=mxcube_pin.has_been_loaded() or loaded,
+                        )
+                        mxcube_pin._set_holder_length(Pin.STD_HOLDERLENGTH)
 
             self._update_sample_changer_state(state_res)
 

--- a/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
+++ b/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
@@ -12,7 +12,6 @@ from typing import (  # noqa: E402
 )
 
 from gevent import sleep  # noqa: E402
-from gevent import monkey
 from mx_robot_library.client.client import Client  # noqa: E402
 from mx_robot_library.config import get_settings as get_robot_settings  # noqa: E402
 from mx_robot_library.schemas.common.path import RobotPaths  # noqa: E402
@@ -20,6 +19,7 @@ from mx_robot_library.schemas.common.position import RobotPositions  # noqa: E40
 from mx_robot_library.schemas.common.sample import Pin as RobotPin
 from mx_robot_library.schemas.common.sample import Puck as RobotPuck  # noqa: E402
 from mx_robot_library.schemas.common.tool import RobotTools  # noqa: E402
+from mx_robot_library.schemas.responses.state import StateResponse
 from pydantic import JsonValue  # noqa: E402
 from typing_extensions import (  # noqa: E402
     Literal,
@@ -340,6 +340,12 @@ class SampleChanger(AbstractSampleChanger):
                     )
                     _mxcube_pin._set_holder_length(Pin.STD_HOLDERLENGTH)
 
+            self._update_sample_changer_state(_state_res)
+
+        except Exception as ex:
+            ex
+
+    def _update_sample_changer_state(self, _state_res: StateResponse):
             # Update SC state
             _is_enabled = _state_res.power and _state_res.remote_mode
             _is_normal_state = _is_enabled and not _state_res.fault_or_stopped
@@ -367,21 +373,12 @@ class SampleChanger(AbstractSampleChanger):
             elif _is_normal_state and _state_res.path.name == "":
                 _state = SampleChangerState.Ready
 
-            # SampleChangerState.Resetting
-            # SampleChangerState.Charging
-            # SampleChangerState.ChangingMode
-            # SampleChangerState.StandBy
-            # SampleChangerState.Initializing
-            # SampleChangerState.Closing
-
             _last_state = self.state
             if _state != _last_state:
                 self._set_state(
                     state=_state,
                     status=SampleChangerState.tostring(_state),
                 )
-        except Exception as ex:
-            ex
 
     def _do_select(self, component) -> None:
         raise NotImplementedError

--- a/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
+++ b/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
@@ -188,24 +188,6 @@ class SampleChanger(AbstractSampleChanger):
         else:
             return state_res.power and state_res.remote_mode
 
-    # @deprecated(
-    #     (
-    #         "The `SampleChanger.chained_load` method should not be used, "
-    #         "call the `SampleChanger.load` method instead."
-    #     )
-    # )
-    # @validate_call
-    # def chained_load(
-    #     self,
-    #     sample_to_unload: Union[tuple[int, int], str],
-    #     sample_to_load: Annotated[
-    #         Union[tuple[int, int], str],
-    #         Field(pattern=r"(\d+):(\d+)"),
-    #     ],
-    # ) -> Union[Pin, None]:
-    #     """ """
-    #     raise NotImplementedError
-
     def chained_load(self, sample_to_unload, sample_to_load):
         """
         Chain the unload of a sample with a load.
@@ -248,28 +230,6 @@ class SampleChanger(AbstractSampleChanger):
 
         self.unload()
         self.load(sample)
-
-    # @validate_call
-    # def load(
-    #     self,
-    #     sample: Annotated[
-    #         Union[tuple[int, int], str],
-    #         Field(pattern=r"(\d+):(\d+)"),
-    #     ],
-    #     wait: bool = True,
-    # ) -> Union[Pin, None]:
-    #     """ """
-    #     raise NotImplementedError
-
-    # def get_loaded_sample(self) -> Union[Pin, None]:
-    #     """ """
-    #     _client = self.get_client()
-    #     _goni_pin = _client.status.state.goni_pin
-    #     if _goni_pin is None:
-    #         return None
-    #     return self.get_component_by_address(
-    #         Pin.get_sample_address(_goni_pin.puck.id, _goni_pin.id),
-    #     )
 
     def is_mounted_sample(self, sample: tuple[int, int]) -> bool:
         return (
@@ -316,7 +276,6 @@ class SampleChanger(AbstractSampleChanger):
 
                     address = Pin.get_sample_address(puck_id, pin_id) # e.g. "1:01"
                     mxcube_pin: Pin = self.get_component_by_address(address)
-                    pin_datamatrix = f"matr{puck_id}_{pin_id}"
                     if robot_pin is not None and robot_puck.name: # check also that barcode exists
                         mxcube_pin._name = str(robot_pin) + "my sample" # This is where sample name is set!!
                         pin_datamatrix = str(robot_pin)
@@ -346,7 +305,18 @@ class SampleChanger(AbstractSampleChanger):
         except Exception as ex:
             ex
 
-    def _update_sample_changer_state(self, state_res: StateResponse):
+    def _update_sample_changer_state(self, state_res: StateResponse)-> None:
+        """Updates the sample changer state
+
+        Parameters
+        ----------
+        state_res : StateResponse
+            The Isara robot state response
+
+        Returns
+        -------
+        None 
+        """
         # Update SC state
         _is_enabled = state_res.power and state_res.remote_mode
         _is_normal_state = _is_enabled and not state_res.fault_or_stopped

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mxcubecore"
-version = "1.195.0.12"
+version = "1.195.0.13"
 license = "LGPL-3.0-or-later"
 description = "Core libraries for the MXCuBE application"
 authors = ["The MXCuBE collaboration <mxcube@esrf.fr>"]


### PR DESCRIPTION
* Updates the names of the Redis keys of the grid scan flow class to be compatible with the latest versions of our software stack
* Minor improvements to the sample changer class (mainly for my understanding and improving readability, but the functionality remains exactly the same as it was before) which include
  * Renaming `Pin` to `MxcubePin` and `Puck` to `MxcubePuck` (not to be confused with `Pin` and `Puck` which come from the `mx-robot-library`)
  * Breaking down the  down the `_do_update_info` method into three methods to improve readabilty
  * Adding dosctrings and type annotations  