### PR TITLE
Pydantic models

### DIFF
--- a/mxcubecore/HardwareObjects/ANSTO/DetectorDistance.py
+++ b/mxcubecore/HardwareObjects/ANSTO/DetectorDistance.py
@@ -148,7 +148,7 @@ class DetectorDistance(AbstractMotor, EPICSActuator):
         tuple
             Low and High limits of a motor.
         """
-        self._nominal_limits = (1, 2000)  # TODO: Need to get the actual limits
+        self._nominal_limits = (136, 708)  # TODO: Hardcoded limits for now!
         return self._nominal_limits
 
     @property

--- a/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
+++ b/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
@@ -1,49 +1,50 @@
 from __future__ import annotations
 
-import logging  # noqa: E402
+import logging
 from asyncio import new_event_loop as asyncio_new_event_loop
-from asyncio import set_event_loop as asyncio_set_event_loop  # noqa: E402
-from functools import lru_cache  # noqa: E402
-from time import time  # noqa: E402
-from typing import (  # noqa: E402
+from asyncio import set_event_loop as asyncio_set_event_loop
+from functools import lru_cache
+from http import HTTPStatus
+from time import time
+from typing import (
     Any,
     Optional,
     Union,
 )
+from urllib.parse import urljoin
 
-from gevent import sleep  # noqa: E402
-from mx_robot_library.client.client import Client  # noqa: E402
-from mx_robot_library.config import get_settings as get_robot_settings  # noqa: E402
-from mx_robot_library.schemas.common.path import RobotPaths  # noqa: E402
-from mx_robot_library.schemas.common.position import RobotPositions  # noqa: E402
+import httpx
+import redis
+from gevent import sleep
+from mx_robot_library.client.client import Client
+from mx_robot_library.config import get_settings as get_robot_settings
+from mx_robot_library.schemas.common.path import RobotPaths
+from mx_robot_library.schemas.common.position import RobotPositions
 from mx_robot_library.schemas.common.sample import Pin as RobotPin
-from mx_robot_library.schemas.common.sample import Puck as RobotPuck  # noqa: E402
-from mx_robot_library.schemas.common.tool import RobotTools  # noqa: E402
+from mx_robot_library.schemas.common.sample import Puck as RobotPuck
+from mx_robot_library.schemas.common.tool import RobotTools
 from mx_robot_library.schemas.responses.state import StateResponse
-from pydantic import JsonValue  # noqa: E402
-from typing_extensions import (  # noqa: E402
+from pydantic import JsonValue
+from typing_extensions import (
     Literal,
     TypedDict,
 )
 
 from mxcubecore.configuration.ansto.config import settings
-from mxcubecore.HardwareObjects.abstract.AbstractSampleChanger import (  # noqa: E402
+from mxcubecore.HardwareObjects.abstract.AbstractSampleChanger import (
     SampleChanger as AbstractSampleChanger,
 )
 from mxcubecore.HardwareObjects.abstract.AbstractSampleChanger import SampleChangerState
-from mxcubecore.HardwareObjects.abstract.sample_changer.Container import (  # noqa: E402
+from mxcubecore.HardwareObjects.abstract.sample_changer.Container import (
     Basket as AbstractPuck,
 )
 from mxcubecore.HardwareObjects.abstract.sample_changer.Container import Container
 from mxcubecore.HardwareObjects.abstract.sample_changer.Container import (
     Pin as AbstractPin,
 )
-from mxcubecore.TaskUtils import task as dtask  # noqa: E402
+from mxcubecore.TaskUtils import task as dtask
 
-from .prefect_flows.prefect_client import MX3PrefectClient  # noqa: E402
-
-# monkey.patch_all()
-
+from .prefect_flows.prefect_client import MX3PrefectClient
 
 hwr_logger = logging.getLogger("HWR")
 robot_config = get_robot_settings()
@@ -140,6 +141,8 @@ class SampleChanger(AbstractSampleChanger):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(self.__TYPE__, False, *args, **kwargs)
+
+        self._pin_name_cache = {}
 
     def init(self) -> None:
         self._selected_sample = -1
@@ -344,9 +347,14 @@ class SampleChanger(AbstractSampleChanger):
         address = MxcubePin.get_sample_address(puck_location, port)  # e.g. "1:01"
         mxcube_pin: MxcubePin = self.get_component_by_address(address)
         if robot_pin is not None and robot_puck.name:  # check also that barcode exists
-            mxcube_pin._name = str(
-                robot_pin
-            )  # TODO: This is where sample name is set!! get name from DL
+            try:
+                sample_name = self.get_sample_by_barcode_and_port(
+                    port=port,
+                    barcode=robot_puck.name.replace("-", ""),
+                )
+            except Exception:
+                sample_name = str(robot_pin)
+            mxcube_pin._name = sample_name
             pin_datamatrix = str(robot_pin)
 
             mxcube_pin._set_info(
@@ -583,3 +591,83 @@ class SampleChanger(AbstractSampleChanger):
     def is_powered(self) -> bool:
         _client = self.get_client()
         return _client.status.state.power
+
+    def get_sample_by_barcode_and_port(self, port: int, barcode: str) -> str:
+        """
+        Gets the pin model from the mx-data-layer-api from port and barcode.
+        The epn is read from redis.
+
+        Returns
+        -------
+        str
+            The sample name
+
+        """
+        with redis.StrictRedis(
+            host=settings.MXCUBE_REDIS_HOST,
+            port=settings.MXCUBE_REDIS_PORT,
+            username=settings.MXCUBE_REDIS_USERNAME,
+            password=settings.MXCUBE_REDIS_PASSWORD,
+            db=settings.MXCUBE_REDIS_DB,
+        ) as redis_connection:
+
+            epn_value: bytes | None = redis_connection.get("epn")
+            if epn_value is None:
+                logging.getLogger("user_level_log").error(
+                    "epn redis key does not exist"
+                )
+                raise ValueError(
+                    f"epn redis key does not exist",
+                )
+
+            epn_string = epn_value.decode("utf-8")
+
+        return self.get_pin_name(
+            epn_string=epn_string,
+            port=port,
+            barcode=barcode.replace("-", ""),
+        )
+
+    def get_pin_name(self, epn_string, port, barcode) -> str:
+        """
+        Get the pin name from the data layer API by barcode, port, and epn.
+        If the pin name is already cached, returns the cached value,
+        otherwise it will call the data layer API to get the pin name.
+
+        Parameters
+        ----------
+        epn_string : str
+            The epn strings
+        port : int
+            The port number of the pin.
+        barcode : str
+            The barcode of the puck containing the pin.
+
+        Returns
+        -------
+        str
+            The sample name.
+        """
+        key = (epn_string, port, barcode)
+        if key in self._pin_name_cache:
+            return self._pin_name_cache[key]
+
+        url = urljoin(
+            settings.DATA_LAYER_API,
+            f"/samples/pins?filter_by_port={port}&filter_by_puck_barcode={barcode}&filter_by_visit_identifier={epn_string}",
+        )
+        r = httpx.get(url)
+        if r.status_code == HTTPStatus.OK:
+            data = r.json()
+            if len(data) == 1:
+                name = data[0]["name"]
+                self._pin_name_cache[key] = name  # Cache only successful result
+                return name
+            else:
+                raise ValueError(
+                    f"Could not get pin by barcode, port, and epn from the data layer API: {r.content}",
+                )
+        else:
+            raise ValueError(
+                f"Could not get pin by barcode, port, and epn from the data layer API: {r.content}",
+            )

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/default_params.yml
@@ -21,15 +21,15 @@ screening:
 
 
 grid_scan:
-  md3_alignment_y_speed: 1  # mm/s
+  md3_alignment_y_speed: 1.0  # mm/s
   omega_range: 0.0  # Degrees
   photon_energy: 13.0  # keV
   resolution: 1.5  # Ångström (16M)
-  transmission: 1  # Percentage
+  transmission: 1.0  # Percentage
 
 one_shot:
   exposure_time: 0.5  # Total exposure time, seconds
-  omega_range: 0  # Degrees
+  omega_range: 0.0  # Degrees
   number_of_frames: 1
   photon_energy: 13.0  # keV
   resolution: 2.0  # Ångström (16M)

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
@@ -114,6 +114,8 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
         dialog : dict
             A dictionary following the JSON schema.
         """
+        resolution_limits = self.resolution.get_limits()
+
         properties = {
             "exposure_time": {
                 "title": "Total Exposure Time [s]",
@@ -139,8 +141,8 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
             "resolution": {
                 "title": "Resolution [Å]",
                 "type": "number",
-                "minimum": 0,  # TODO: get limits from distance PV
-                "maximum": 3000,  # TODO: get limits from distance PV
+                "minimum": resolution_limits[0],
+                "maximum": resolution_limits[1],
                 "default": float(self._get_dialog_box_param("resolution")),
                 "widget": "textarea",
             },

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/full_dataset_collection_flow.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 
+from mx3_beamline_library.devices.beam import energy_master
+
 from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 
@@ -32,11 +34,13 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
         None
         """
         # This is the payload we get from the UI
-        dialog_box_model = FullDatasetDialogBox.parse_obj(dialog_box_parameters)
+        dialog_box_model = FullDatasetDialogBox.model_validate(dialog_box_parameters)
+
+        photon_energy = energy_master.get()
 
         detector_distance = self._resolution_to_distance(
             dialog_box_model.resolution,
-            energy=dialog_box_model.photon_energy,
+            energy=photon_energy,
         )
 
         full_dataset_params = FullDatasetParams(
@@ -46,7 +50,7 @@ class FullDatasetFlow(AbstractPrefectWorkflow):
             count_time=None,
             number_of_frames=dialog_box_model.number_of_frames,
             detector_distance=detector_distance,
-            photon_energy=dialog_box_model.photon_energy,
+            photon_energy=photon_energy,
             beam_size=(80, 80),  # TODO: get beam size,
             # Convert transmission percentage to a value between 0 and 1
             transmission=dialog_box_model.transmission / 100,

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/grid_scan_flow.py
@@ -7,6 +7,7 @@ import numpy as np
 import numpy.typing as npt
 import redis
 import redis.asyncio
+from mx3_beamline_library.devices.beam import energy_master
 
 from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.HardwareObjects.SampleView import (
@@ -94,10 +95,12 @@ class GridScanFlow(AbstractPrefectWorkflow):
         else:
             grid_scan_id = int(redis_grid_scan_id) + 1
 
+        photon_energy = energy_master.get()
+
         default_resolution = float(self.redis_connection.get("grid_scan:resolution"))
         detector_distance = self._resolution_to_distance(
             default_resolution,
-            energy=dialog_box_model.photon_energy,
+            energy=photon_energy,
         )
         logging.getLogger("HWR").info(
             f"Detector distance corresponding to {default_resolution} A: {detector_distance} [m]"
@@ -113,8 +116,8 @@ class GridScanFlow(AbstractPrefectWorkflow):
             number_of_columns=num_cols,
             number_of_rows=num_rows,
             detector_distance=detector_distance,
-            photon_energy=dialog_box_model.photon_energy,
-            omega_range=dialog_box_model.omega_range,
+            photon_energy=photon_energy,
+            omega_range=float(self._get_dialog_box_param("omega_range")),
             md3_alignment_y_speed=dialog_box_model.md3_alignment_y_speed,
             hardware_trigger=True,
             number_of_processes=settings.GRID_SCAN_NUMBER_OF_PROCESSES,

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/one_shot_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/one_shot_flow.py
@@ -1,6 +1,8 @@
 import asyncio
 import logging
 
+from mx3_beamline_library.devices.beam import energy_master
+
 from mxcubecore.configuration.ansto.config import settings
 from mxcubecore.queue_entry.base_queue_entry import QueueExecutionException
 
@@ -34,9 +36,11 @@ class OneShotFlow(AbstractPrefectWorkflow):
         # This is the payload we get from the UI
         dialog_box_model = OneShotDialogBox.model_validate(dialog_box_parameters)
 
+        photon_energy = energy_master.get()
+
         detector_distance = self._resolution_to_distance(
             dialog_box_model.resolution,
-            energy=dialog_box_model.photon_energy,
+            energy=photon_energy,
         )
 
         one_shot_params = OneShotParams(
@@ -46,7 +50,7 @@ class OneShotFlow(AbstractPrefectWorkflow):
             count_time=None,
             number_of_frames=1,
             detector_distance=detector_distance,
-            photon_energy=dialog_box_model.photon_energy,
+            photon_energy=photon_energy,
             beam_size=(80, 80),  # TODO: get beam size,
             # Convert transmission percentage to a value between 0 and 1
             transmission=dialog_box_model.transmission / 100,

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/one_shot_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/one_shot_flow.py
@@ -105,6 +105,8 @@ class OneShotFlow(AbstractPrefectWorkflow):
         dialog : dict
             A dictionary following the JSON schema.
         """
+        resolution_limits = self.resolution.get_limits()
+
         properties = {
             "exposure_time": {
                 "title": "Total Exposure Time [s]",
@@ -123,8 +125,8 @@ class OneShotFlow(AbstractPrefectWorkflow):
             "resolution": {
                 "title": "Resolution [Å]",
                 "type": "number",
-                "minimum": 0,  # TODO: get limits from distance PV
-                "maximum": 3000,  # TODO: get limits from distance PV
+                "minimum": resolution_limits[0],
+                "maximum": resolution_limits[1],
                 "default": float(self._get_dialog_box_param("resolution")),
                 "widget": "textarea",
             },

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/common.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/common.py
@@ -14,7 +14,7 @@ class DataCollectionDialogBoxBase(BaseModel):
         "distance in meters internally, which is the parameter "
         "prefect expects"
     )
-    photon_energy: float = Field(description="Photon energy in keV")
+    # photon_energy: float = Field(description="Photon energy in keV")
     transmission: float = Field(description="Measured in percentage")
     sample_id: int | None = None
 

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/grid_scan.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/grid_scan.py
@@ -11,8 +11,7 @@ from pydantic import (
 
 class GridScanDialogBox(BaseModel):
     md3_alignment_y_speed: float
-    omega_range: float
-    photon_energy: float
+    # photon_energy: float
     transmission: float = Field(description="Measured in percentage")
 
 

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/screening.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/schemas/screening.py
@@ -5,7 +5,6 @@ from .common import (
 
 
 class ScreeningDialogBox(DataCollectionDialogBoxBase):
-    processing_pipeline: str = "dials"
     crystal_counter: int = 0
     number_of_frames: int
 

--- a/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
+++ b/mxcubecore/HardwareObjects/ANSTO/prefect_flows/screening_flow.py
@@ -113,6 +113,8 @@ class ScreeningFlow(AbstractPrefectWorkflow):
         dialog : dict
             A dictionary following the JSON schema.
         """
+        resolution_limits = self.resolution.get_limits()
+
         properties = {
             "exposure_time": {
                 "title": "Total Exposure Time [s]",
@@ -138,8 +140,8 @@ class ScreeningFlow(AbstractPrefectWorkflow):
             "resolution": {
                 "title": "Resolution [Å]",
                 "type": "number",
-                "minimum": 0,  # TODO: get limits from distance PV
-                "maximum": 3000,  # TODO: get limits from distance PV
+                "minimum": resolution_limits[0],
+                "maximum": resolution_limits[1],
                 "default": float(self._get_dialog_box_param("resolution")),
                 "widget": "textarea",
             },

--- a/mxcubecore/configuration/ansto/energy.xml
+++ b/mxcubecore/configuration/ansto/energy.xml
@@ -1,3 +1,4 @@
 <object class="ANSTO.Energy">
   <username>energy</username>
+  <read_only>True</read_only>
 </object>

--- a/mxcubecore/configuration/ansto/mockup/energy.xml
+++ b/mxcubecore/configuration/ansto/mockup/energy.xml
@@ -1,3 +1,4 @@
 <object class="ANSTO.Energy">
   <username>energy</username>
+  <read_only>True</read_only>
 </object>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mxcubecore"
-version = "1.195.0.20"
+version = "1.195.0.21"
 license = "LGPL-3.0-or-later"
 description = "Core libraries for the MXCuBE application"
 authors = ["The MXCuBE collaboration <mxcube@esrf.fr>"]


### PR DESCRIPTION
* Fix dialog box pydantic models
* Get energy value from energy PV rather than from the dialog box input parameter (as energy no longer and input param)
* Display sample name instead of barcode in the `sample` tab of mxcube
* Display errors in mxcube if for some reason robot mount fails
* Adds sample-detector distance limits
* Adds limits to resolution to dialog boxes
* Energy is now read only