### PR TITLE
Refresh samples

### DIFF
--- a/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
+++ b/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
@@ -484,45 +484,55 @@ class SampleChanger(AbstractSampleChanger):
         else:
             prefect_prefetch = None
 
-        # self._check_if_robot_is_ready()
-        # Mock mounting a sample for now
-        for puck_location in self.puck_location_list:
-            for port in range(1, self.no_of_samples_in_basket + 1):
-                address = MxcubePin.get_sample_address(
-                    puck_location, port
-                )  # e.g. "1:01"
-                mxcube_pin: MxcubePin = self.get_component_by_address(address)
-                loaded: bool = False
-                if (puck_location, port) == (
-                    prefect_sample_to_mount["puck"],
-                    prefect_sample_to_mount["id"],
-                ):
-                    loaded = True
+        self._check_if_robot_is_ready()
+        # # Mock mounting a sample for now
+        # for puck_location in self.puck_location_list:
+        #     for port in range(1, self.no_of_samples_in_basket + 1):
+        #         address = MxcubePin.get_sample_address(
+        #             puck_location, port
+        #         )  # e.g. "1:01"
+        #         mxcube_pin: MxcubePin = self.get_component_by_address(address)
+        #         loaded: bool = False
+        #         if (puck_location, port) == (
+        #             prefect_sample_to_mount["puck"],
+        #             prefect_sample_to_mount["id"],
+        #         ):
+        #             loaded = True
 
-                mxcube_pin._set_loaded(
-                    loaded=loaded,
-                    has_been_loaded=mxcube_pin.has_been_loaded() or loaded,
-                )
-                mxcube_pin._set_holder_length(MxcubePin.STD_HOLDERLENGTH)
-                if loaded:
-                    self._trigger_loaded_sample_changed_event(mxcube_pin)
+        #         mxcube_pin._set_loaded(
+        #             loaded=loaded,
+        #             has_been_loaded=mxcube_pin.has_been_loaded() or loaded,
+        #         )
+        #         mxcube_pin._set_holder_length(MxcubePin.STD_HOLDERLENGTH)
+        #         if loaded:
+        #             self._trigger_loaded_sample_changed_event(mxcube_pin)
 
-        # FIXME! uncomment
         try:
             # Mount pin using `mount` Prefect Flow
-            # _prefect_mount_client = MX3SyncPrefectClient(
-            #     name=self._mount_deployment_name,
-            #     parameters={
-            #         "pin": prefect_sample_to_mount,
-            #         "prepick_pin": prefect_prefetch,
-            #     },
-            # )
+            _prefect_mount_client = MX3SyncPrefectClient(
+                name=self._mount_deployment_name,
+                parameters={
+                    "pin": prefect_sample_to_mount,
+                    "prepick_pin": prefect_prefetch,
+                },
+            )
 
-            # response = _prefect_mount_client.trigger_flow(wait=True)
-            # if response.state.type != StateType.COMPLETED:
-            #     raise RuntimeError(f"{response.state.message}")
-            pass
-
+            response = _prefect_mount_client.trigger_flow(wait=True)
+            if response.state.type != StateType.COMPLETED:
+                raise RuntimeError(f"{response.state.message}")
+            
+            # TODO: double check if this is necessary
+            puck_location = prefect_sample_to_mount["puck"]
+            port = prefect_sample_to_mount["id"]
+            address = MxcubePin.get_sample_address(
+                puck_location, port
+            )  # e.g. "1:01"
+            mxcube_pin: MxcubePin = self.get_component_by_address(address)
+            mxcube_pin._set_loaded(
+                loaded=True,
+                has_been_loaded=mxcube_pin.has_been_loaded() or True,
+            )
+            self._trigger_loaded_sample_changed_event(mxcube_pin)
         except Exception as ex:
             logging.getLogger("user_level_log").error(
                 f"Failed to mount sample. {str(ex)}"
@@ -631,21 +641,19 @@ class SampleChanger(AbstractSampleChanger):
         -------
         None
         """
-        # self._check_if_robot_is_ready()
+        self._check_if_robot_is_ready()
 
-        # FIXME! uncomment
-        # Mount pin using `unmount` Prefect Flow
+        # Unmount pin using `unmount` Prefect Flow
         current_sample = self.get_loaded_sample()
         try:
-            # _prefect_unmount_client = MX3SyncPrefectClient(
-            #     name=self._unmount_deployment_name,
-            #     parameters={},
-            # )
+            _prefect_unmount_client = MX3SyncPrefectClient(
+                name=self._unmount_deployment_name,
+                parameters={},
+            )
 
-            # response = _prefect_unmount_client.trigger_flow(wait=True)
-            # if response.state.type != StateType.COMPLETED:
-            #     raise RuntimeError(f"{response.state.message}")
-            print("unload")
+            response = _prefect_unmount_client.trigger_flow(wait=True)
+            if response.state.type != StateType.COMPLETED:
+                raise RuntimeError(f"{response.state.message}")
             current_sample._set_loaded(False, has_been_loaded=True)
             self._trigger_loaded_sample_changed_event(current_sample)
         except Exception as ex:
@@ -736,10 +744,18 @@ class SampleChanger(AbstractSampleChanger):
         except Exception:
             return []
 
-    def _initialise_pucks_and_pins(self, pucks_by_epn) -> None:
+    def _initialise_pucks_and_pins(self, pucks_by_epn: list[dict]) -> None:
         """
-        Initialises the pucks and pins in the sample changer based on
-        the pucks in the data layer API for the current EPN.
+        Initialises the pucks and pins. All pins and pucks are added to the sample changer,
+        but only the pucks that are loaded in the robot and match the current 
+        EPN will be marked as present. 
+        NOTE: It is important to add all pins and pucks for the refresh button to work in the UI
+
+        Parameters
+        ----------
+        pucks_by_epn : list[dict]
+            A list of pucks from the data layer API, each puck is a dictionary
+            containing the puck information. This is used to get the sample names for the pins.
         """
         self.no_of_baskets = (
             robot_config.ASC_NUM_PUCKS
@@ -776,6 +792,16 @@ class SampleChanger(AbstractSampleChanger):
                 )
 
     def refresh_puck_info(self) -> dict[str, Any]:
+        """Refreshes the puck and pin information from the robot and updates the sample
+        changer state accordingly. This method is called when the user clicks the refresh
+        button in the UI.
+        
+        Returns
+        -------
+        dict
+            A dictionary containing the sample information for each pin, in the format
+            expected by the UI.
+        """
 
         logging.getLogger("HWR").info("Refreshing sample info...")
         client = self.get_client()

--- a/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
+++ b/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
@@ -196,7 +196,12 @@ class SampleChanger(AbstractSampleChanger):
                 puck_location,
                 samples_num=self.no_of_samples_in_basket,
             )
-            basket._set_info(present=present, id=str(puck_location), scanned=False)
+            # NOTE: Whether a puck is present or not is determined by the id which is weird!!!
+            basket._set_info(
+                present=present,
+                id=str(puck_location) if present else None,
+                scanned=False,
+            )
             self._add_component(basket)
 
         self._set_state(SampleChangerState.Unknown)
@@ -824,7 +829,7 @@ class SampleChanger(AbstractSampleChanger):
                 pin: MxcubePin = self.get_component_by_address(address)
                 pin._set_info(
                     present=False,
-                    id=address,
+                    id=None,
                     scanned=False,
                 )
 
@@ -882,7 +887,7 @@ class SampleChanger(AbstractSampleChanger):
             if i not in self.puck_location_list:
                 baskets[i-1]._set_info(
                 present=False,
-                id=str(i),
+                id=None,
                 scanned=False,
                 )
             else:

--- a/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
+++ b/mxcubecore/HardwareObjects/ANSTO/SampleChanger.py
@@ -485,27 +485,6 @@ class SampleChanger(AbstractSampleChanger):
             prefect_prefetch = None
 
         self._check_if_robot_is_ready()
-        # # Mock mounting a sample for now
-        # for puck_location in self.puck_location_list:
-        #     for port in range(1, self.no_of_samples_in_basket + 1):
-        #         address = MxcubePin.get_sample_address(
-        #             puck_location, port
-        #         )  # e.g. "1:01"
-        #         mxcube_pin: MxcubePin = self.get_component_by_address(address)
-        #         loaded: bool = False
-        #         if (puck_location, port) == (
-        #             prefect_sample_to_mount["puck"],
-        #             prefect_sample_to_mount["id"],
-        #         ):
-        #             loaded = True
-
-        #         mxcube_pin._set_loaded(
-        #             loaded=loaded,
-        #             has_been_loaded=mxcube_pin.has_been_loaded() or loaded,
-        #         )
-        #         mxcube_pin._set_holder_length(MxcubePin.STD_HOLDERLENGTH)
-        #         if loaded:
-        #             self._trigger_loaded_sample_changed_event(mxcube_pin)
 
         try:
             # Mount pin using `mount` Prefect Flow
@@ -520,13 +499,10 @@ class SampleChanger(AbstractSampleChanger):
             response = _prefect_mount_client.trigger_flow(wait=True)
             if response.state.type != StateType.COMPLETED:
                 raise RuntimeError(f"{response.state.message}")
-            
-            # TODO: double check if this is necessary
+
             puck_location = prefect_sample_to_mount["puck"]
             port = prefect_sample_to_mount["id"]
-            address = MxcubePin.get_sample_address(
-                puck_location, port
-            )  # e.g. "1:01"
+            address = MxcubePin.get_sample_address(puck_location, port)  # e.g. "1:01"
             mxcube_pin: MxcubePin = self.get_component_by_address(address)
             mxcube_pin._set_loaded(
                 loaded=True,
@@ -747,8 +723,8 @@ class SampleChanger(AbstractSampleChanger):
     def _initialise_pucks_and_pins(self, pucks_by_epn: list[dict]) -> None:
         """
         Initialises the pucks and pins. All pins and pucks are added to the sample changer,
-        but only the pucks that are loaded in the robot and match the current 
-        EPN will be marked as present. 
+        but only the pucks that are loaded in the robot and match the current
+        EPN will be marked as present.
         NOTE: It is important to add all pins and pucks for the refresh button to work in the UI
 
         Parameters
@@ -795,7 +771,7 @@ class SampleChanger(AbstractSampleChanger):
         """Refreshes the puck and pin information from the robot and updates the sample
         changer state accordingly. This method is called when the user clicks the refresh
         button in the UI.
-        
+
         Returns
         -------
         dict

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "mxcubecore"
-version = "1.195.0.56"
+version = "1.195.0.57"
 license = "LGPL-3.0-or-later"
 description = "Core libraries for the MXCuBE application"
 authors = ["The MXCuBE collaboration <mxcube@esrf.fr>"]


### PR DESCRIPTION
* Adds the `refresh_puck_info` method to update sample information via the UI `refresh` button
* Polling the data layer api is no longer needed as now all sample-information updates is done by the `refresh` button